### PR TITLE
Add compact scrolling weather ticker to dashboard weather card

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -227,3 +227,51 @@ body {
   background-position: center;
   background-size: 28px 28px;
 }
+
+
+.weather-ticker-strip {
+  overflow: hidden;
+  border: 1px solid rgb(var(--border));
+  border-radius: 0.75rem;
+  background: rgb(var(--surface2));
+  padding: 0.5rem 0;
+}
+
+.weather-ticker-track {
+  display: flex;
+  width: max-content;
+  align-items: center;
+  gap: 0.5rem;
+  padding-right: 0.5rem;
+  animation: weather-ticker-scroll 24s linear infinite;
+}
+
+.weather-ticker-item {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  background: rgb(var(--surface));
+  border: 1px solid rgb(var(--border));
+  color: rgb(var(--text));
+  padding: 0.2rem 0.7rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
+@keyframes weather-ticker-scroll {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .weather-ticker-track {
+    animation: none;
+  }
+}

--- a/src/components/dashboard/weather-ticker.tsx
+++ b/src/components/dashboard/weather-ticker.tsx
@@ -99,6 +99,14 @@ export function WeatherTicker({
   }
 
   const impact = weatherImpact(forecast);
+  const tickerItems = buildTickerItems({
+    locationLabel,
+    currentCondition: forecast.current.condition,
+    currentTemp: forecast.current.temp,
+    precipitationChance: forecast.current.precipitationChance,
+    windKph: forecast.current.windKph,
+    impact: impact.title
+  });
 
   return (
     <Card className="overflow-hidden">
@@ -125,6 +133,18 @@ export function WeatherTicker({
             <BadgeStat icon={<Droplets className="h-3 w-3" />} label={`Rain ${forecast.current.precipitationChance}%`} />
           )}
         </div>
+
+        {compact && tickerItems.length > 0 && (
+          <div className="weather-ticker-strip" aria-label="Weather ticker updates">
+            <div className="weather-ticker-track">
+              {[...tickerItems, ...tickerItems].map((item, index) => (
+                <span key={`${item}-${index}`} className="weather-ticker-item">
+                  {item}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
 
         <div className="rounded-xl border border-semantic-border bg-semantic-surface2 p-3">
           <p className="text-xs font-semibold uppercase tracking-[0.14em] text-semantic-muted">Next 6 Hours</p>
@@ -170,6 +190,32 @@ export function WeatherTicker({
       </CardBody>
     </Card>
   );
+}
+
+function buildTickerItems({
+  locationLabel,
+  currentCondition,
+  currentTemp,
+  precipitationChance,
+  windKph,
+  impact
+}: {
+  locationLabel?: string | null;
+  currentCondition: string;
+  currentTemp: number;
+  precipitationChance?: number;
+  windKph?: number;
+  impact: string;
+}) {
+  const items = [
+    locationLabel ? `Location: ${locationLabel}` : "Location: Service area",
+    `Now: ${currentTemp}° and ${currentCondition}`,
+    precipitationChance != null ? `Rain chance: ${precipitationChance}%` : null,
+    windKph != null ? `Wind: ${windKph} kph` : null,
+    `Demand signal: ${impact}`
+  ].filter(Boolean);
+
+  return items as string[];
 }
 
 function BadgeStat({ icon, label }: { icon: ReactNode; label: string }) {


### PR DESCRIPTION
### Motivation
- Surface at-a-glance weather signals on the dashboard after the service-area location is saved so teams can spot urgent demand without leaving the overview page.

### Description
- Added a compact, horizontally scrolling ticker to the `WeatherTicker` component that renders when `compact` is true and a weather location/forecast is available (`src/components/dashboard/weather-ticker.tsx`).
- Introduced `buildTickerItems` helper to compose ticker messages from forecast and saved location data (location, current conditions, precip chance, wind, and demand/impact text).
- Added global CSS for ticker layout and animation plus a reduced-motion fallback in `src/app/globals.css` and duplicated the items stream for a seamless loop.
- Kept existing non-compact behavior intact (full impact card and details remain unchanged).

### Testing
- Ran `npm run lint` and the lint step completed with no errors.
- Ran `npm run typecheck` and TypeScript typechecking completed with no errors.
- Launched the app in demo mode and executed an automated Playwright capture of `/dashboard`, producing the visual artifact `artifacts/weather-ticker-dashboard.png` to validate rendering and animation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa3fde1910832a8d78ac398980f2c1)