### PR TITLE
Improve operator pilot activation diagnostics

### DIFF
--- a/scripts/operator-healthcheck.ts
+++ b/scripts/operator-healthcheck.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 import fs from "node:fs";
 import path from "node:path";
+import net from "node:net";
 
 function loadEnvFromFile(filePath: string) {
   if (!fs.existsSync(filePath)) return;
@@ -55,6 +56,49 @@ function pushResult(list: CheckResult[], result: CheckResult) {
   list.push(result);
 }
 
+function parseSupabaseHost(url: string) {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return "";
+  }
+}
+
+function parseSupabasePort(url: string) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.port) return Number(parsed.port);
+    return parsed.protocol === "https:" ? 443 : 80;
+  } catch {
+    return null;
+  }
+}
+
+function isLocalSupabaseUrl(url: string) {
+  const hostname = parseSupabaseHost(url);
+  return hostname === "127.0.0.1" || hostname === "localhost";
+}
+
+async function isPortListening(host: string, port: number) {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  return new Promise<boolean>((resolve) => {
+    const socket = net.createConnection({ host, port });
+    let settled = false;
+
+    const finish = (result: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(result);
+    };
+
+    socket.setTimeout(1_000);
+    socket.once("connect", () => finish(true));
+    socket.once("timeout", () => finish(false));
+    socket.once("error", () => finish(false));
+  });
+}
+
 async function checkTableExists(supabase: any, table: string): Promise<CheckResult> {
   const { error } = await supabase.from(table).select("id", { head: true, count: "exact" }).limit(1);
   if (error) {
@@ -79,6 +123,7 @@ async function main() {
   const supabaseUrl = String(process.env.NEXT_PUBLIC_SUPABASE_URL || "").trim();
   const serviceRole = String(process.env.SUPABASE_SERVICE_ROLE_KEY || "").trim();
   const webhookSecret = String(process.env.WEBHOOK_SHARED_SECRET || "").trim();
+  const appUrl = String(process.env.NEXT_PUBLIC_APP_URL || "").trim();
 
   if (!supabaseUrl || !serviceRole) {
     pushResult(results, {
@@ -98,12 +143,34 @@ async function main() {
     detail: "Supabase URL + service role key present."
   });
 
+  if (!appUrl) {
+    pushResult(results, {
+      name: "app_url",
+      status: "FAIL",
+      detail: "NEXT_PUBLIC_APP_URL is not set.",
+      remediation: "Set NEXT_PUBLIC_APP_URL to the public app origin before pilot activation."
+    });
+  } else if (!/^https?:\/\//i.test(appUrl)) {
+    pushResult(results, {
+      name: "app_url",
+      status: "FAIL",
+      detail: `NEXT_PUBLIC_APP_URL must start with http:// or https:// (got ${appUrl}).`,
+      remediation: "Set NEXT_PUBLIC_APP_URL to a valid origin such as https://app.example.com."
+    });
+  } else {
+    pushResult(results, {
+      name: "app_url",
+      status: "PASS",
+      detail: `NEXT_PUBLIC_APP_URL configured (${appUrl}).`
+    });
+  }
+
   if (!webhookSecret) {
     pushResult(results, {
       name: "webhook_secret",
-      status: "WARN",
+      status: "FAIL",
       detail: "WEBHOOK_SHARED_SECRET is not set.",
-      remediation: "Set WEBHOOK_SHARED_SECRET before exposing webhook endpoints publicly."
+      remediation: "Set WEBHOOK_SHARED_SECRET. Mutating webhook routes now fail closed without it."
     });
   } else {
     pushResult(results, {
@@ -119,11 +186,18 @@ async function main() {
 
   const { error: connectivityError } = await supabase.from("accounts").select("id", { head: true, count: "exact" }).limit(1);
   if (connectivityError) {
+    const host = parseSupabaseHost(supabaseUrl);
+    const port = parseSupabasePort(supabaseUrl);
+    const localDbDown =
+      isLocalSupabaseUrl(supabaseUrl) && port !== null && !(await isPortListening(host, port));
+
     pushResult(results, {
       name: "supabase_connectivity",
       status: "FAIL",
       detail: `Supabase connectivity check failed (${connectivityError.message}).`,
-      remediation: "Confirm URL/key pair and that the target project is reachable."
+      remediation: localDbDown
+        ? "Local Supabase does not appear to be running. Start it with `npm run db:start`, then run `npm run db:push` and retry."
+        : "Confirm URL/key pair and that the target project is reachable."
     });
 
     printReport(results);
@@ -211,6 +285,27 @@ async function main() {
   }
 
   if (tenantId) {
+    const { count: membershipCount, error: membershipError } = await supabase
+      .from("v2_tenant_memberships")
+      .select("id", { count: "exact", head: true })
+      .eq("tenant_id", tenantId)
+      .eq("is_active", true);
+
+    if (membershipError || !Number(membershipCount || 0)) {
+      pushResult(results, {
+        name: "tenant_memberships",
+        status: "FAIL",
+        detail: membershipError?.message || "No active tenant memberships found.",
+        remediation: "Seed the operator with OPERATOR_USER_ID so at least one active user is wired to the tenant."
+      });
+    } else {
+      pushResult(results, {
+        name: "tenant_memberships",
+        status: "PASS",
+        detail: `Active tenant memberships: ${membershipCount}.`
+      });
+    }
+
     const { count: territoryCount, error: territoryError } = await supabase
       .from("v2_territories")
       .select("id", { count: "exact", head: true })
@@ -304,7 +399,6 @@ async function main() {
     });
   }
 
-  const appUrl = String(process.env.NEXT_PUBLIC_APP_URL || "").trim();
   const inngestConfigured = Boolean(process.env.INNGEST_EVENT_KEY && process.env.INNGEST_SIGNING_KEY);
   const inngestEndpointConfigured = Boolean(appUrl);
   if (inngestConfigured && inngestEndpointConfigured) {
@@ -316,9 +410,9 @@ async function main() {
   } else {
     pushResult(results, {
       name: "inngest",
-      status: "WARN",
+      status: "FAIL",
       detail: "Inngest config is incomplete (missing keys and/or NEXT_PUBLIC_APP_URL).",
-      remediation: "Set INNGEST_EVENT_KEY, INNGEST_SIGNING_KEY, and NEXT_PUBLIC_APP_URL."
+      remediation: "Set INNGEST_EVENT_KEY, INNGEST_SIGNING_KEY, and NEXT_PUBLIC_APP_URL before live pilot activation."
     });
   }
 

--- a/scripts/operator-test.mjs
+++ b/scripts/operator-test.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
+import net from "node:net";
 import path from "node:path";
 import { createClient } from "@supabase/supabase-js";
 
@@ -37,6 +38,54 @@ loadEnvFromFile(path.join(process.cwd(), ".env"));
 function envTrue(name) {
   const value = String(process.env[name] || "").trim().toLowerCase();
   return value === "1" || value === "true" || value === "on" || value === "yes";
+}
+
+function parseSupabaseHost(url) {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return "";
+  }
+}
+
+function parseSupabasePort(url) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.port) return Number(parsed.port);
+    return parsed.protocol === "https:" ? 443 : 80;
+  } catch {
+    return null;
+  }
+}
+
+function isLocalSupabaseUrl(url) {
+  const hostname = parseSupabaseHost(url);
+  return hostname === "127.0.0.1" || hostname === "localhost";
+}
+
+async function isPortListening(host, port) {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port });
+    let settled = false;
+
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(result);
+    };
+
+    socket.setTimeout(1000);
+    socket.once("connect", () => finish(true));
+    socket.once("timeout", () => finish(false));
+    socket.once("error", () => finish(false));
+  });
+}
+
+async function canReachSupabase(supabase) {
+  const { error } = await supabase.from("accounts").select("id", { head: true, count: "exact" }).limit(1);
+  return !error;
 }
 
 function printSimulated() {
@@ -327,6 +376,19 @@ async function main() {
   const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY, {
     auth: { autoRefreshToken: false, persistSession: false }
   });
+
+  if (!(await canReachSupabase(supabase))) {
+    const supabaseUrl = String(process.env.NEXT_PUBLIC_SUPABASE_URL || "").trim();
+    const host = parseSupabaseHost(supabaseUrl);
+    const port = parseSupabasePort(supabaseUrl);
+    const localDbDown = isLocalSupabaseUrl(supabaseUrl) && host && port !== null && !(await isPortListening(host, port));
+
+    throw new Error(
+      localDbDown
+        ? "Local Supabase is not reachable. Start it with `npm run db:start`, run `npm run db:push`, then retry `npm run operator:seed` and `npm run operator-test`."
+        : "Operator test could not reach Supabase. Confirm the configured URL/key pair and that the target project is reachable."
+    );
+  }
 
   const tenantId = await resolveOperatorTenantId(supabase);
 
@@ -626,6 +688,38 @@ async function main() {
 }
 
 main().catch((error) => {
+  if (error instanceof Error && error.message.includes("Local Supabase is not reachable")) {
+    console.error(error.message);
+    process.exit(1);
+  }
+
+  if (error instanceof Error && error.message.includes("Operator test could not reach Supabase")) {
+    console.error(error.message);
+    process.exit(1);
+  }
+
+  if (error instanceof TypeError && error.message === "fetch failed") {
+    const supabaseUrl = String(process.env.NEXT_PUBLIC_SUPABASE_URL || "").trim();
+    const host = parseSupabaseHost(supabaseUrl);
+    const port = parseSupabasePort(supabaseUrl);
+
+    const finish = async () => {
+      const localDbDown = isLocalSupabaseUrl(supabaseUrl) && host && port !== null && !(await isPortListening(host, port));
+      if (localDbDown) {
+        console.error("Local Supabase is not reachable. Start it with `npm run db:start`, run `npm run db:push`, then retry `npm run operator:seed` and `npm run operator-test`.");
+      } else {
+        console.error("Operator test could not reach Supabase. Confirm the configured URL/key pair and that the target project is reachable.");
+      }
+      process.exit(1);
+    };
+
+    finish().catch(() => {
+      console.error("Operator test could not reach Supabase. Confirm the configured URL/key pair and that the target project is reachable.");
+      process.exit(1);
+    });
+    return;
+  }
+
   console.error(error instanceof Error ? error.message : error);
   process.exit(1);
 });

--- a/scripts/seed-operator.ts
+++ b/scripts/seed-operator.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 import fs from "node:fs";
+import net from "node:net";
 import path from "node:path";
 
 function loadEnvFromFile(filePath: string) {
@@ -33,6 +34,59 @@ if (!SUPABASE_URL || !SERVICE_ROLE) {
 const supabase = createClient(SUPABASE_URL, SERVICE_ROLE, {
   auth: { autoRefreshToken: false, persistSession: false }
 });
+
+function parseSupabaseHost(url: string) {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return "";
+  }
+}
+
+function parseSupabasePort(url: string) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.port) return Number(parsed.port);
+    return parsed.protocol === "https:" ? 443 : 80;
+  } catch {
+    return null;
+  }
+}
+
+function isLocalSupabaseUrl(url: string) {
+  const hostname = parseSupabaseHost(url);
+  return hostname === "127.0.0.1" || hostname === "localhost";
+}
+
+async function isPortListening(host: string, port: number) {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  return new Promise<boolean>((resolve) => {
+    const socket = net.createConnection({ host, port });
+    let settled = false;
+
+    const finish = (result: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(result);
+    };
+
+    socket.setTimeout(1_000);
+    socket.once("connect", () => finish(true));
+    socket.once("timeout", () => finish(false));
+    socket.once("error", () => finish(false));
+  });
+}
+
+function formatConnectivityGuidance() {
+  const host = parseSupabaseHost(SUPABASE_URL);
+  const port = parseSupabasePort(SUPABASE_URL);
+  if (isLocalSupabaseUrl(SUPABASE_URL) && port !== null) {
+    return `Local Supabase is not reachable at ${host}:${port}. Start it with \`npm run db:start\`, then apply migrations with \`npm run db:push\` and retry \`npm run operator:seed\`.`;
+  }
+
+  return "Confirm NEXT_PUBLIC_SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY and that the target Supabase project is reachable.";
+}
 
 const OPERATOR_PROFILE = String(process.env.OPERATOR_PROFILE || "ny_restoration").trim().toLowerCase();
 const IS_SUFFOLK_PROFILE = OPERATOR_PROFILE === "suffolk_restoration";
@@ -625,6 +679,27 @@ async function main() {
 }
 
 main().catch((error) => {
+  const errorText = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  if (errorText.includes("fetch failed")) {
+    const host = parseSupabaseHost(SUPABASE_URL);
+    const port = parseSupabasePort(SUPABASE_URL);
+    const checkPort = async () => {
+      if (!host || port === null) return false;
+      return isPortListening(host, port);
+    };
+
+    checkPort()
+      .then((listening) => {
+        console.error(listening ? "Seed failed while contacting Supabase. Check credentials and schema state." : formatConnectivityGuidance());
+        process.exit(1);
+      })
+      .catch(() => {
+        console.error(formatConnectivityGuidance());
+        process.exit(1);
+      });
+    return;
+  }
+
   console.error(error instanceof Error ? error.message : error);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- make  fail clearly when critical live-pilot settings are missing
- detect when local Supabase is unreachable and return actionable remediation instead of generic 
- make  stop early on Supabase connectivity problems so it does not misreport tenant-seeding failures

## Why This Improves the Product
This improves product quality and operator trust during activation. Instead of vague runtime errors, the pilot workflow now tells the operator exactly what is wrong and what to do next. That reduces setup friction, shortens time-to-value, and makes the live deployment path feel production-ready.

## Validation
- 
> service-butler-ai@0.1.0 typecheck
> tsc -p tsconfig.typecheck.json --noEmit
- 
> service-butler-ai@0.1.0 operator-healthcheck
> mkdir -p .tmp/operator && npx tsc scripts/operator-healthcheck.ts --target ES2022 --module commonjs --moduleResolution node --esModuleInterop --skipLibCheck --outDir .tmp/operator && node .tmp/operator/operator-healthcheck.js


Service Butler Operator Healthcheck

[PASS] supabase_env: Supabase URL + service role key present.
[PASS] app_url: NEXT_PUBLIC_APP_URL configured (http://localhost:3000).
[PASS] webhook_secret: WEBHOOK_SHARED_SECRET configured.
[FAIL] supabase_connectivity: Supabase connectivity check failed (TypeError: fetch failed).
       remediation: Local Supabase does not appear to be running. Start it with `npm run db:start`, then run `npm run db:push` and retry.
- 
> service-butler-ai@0.1.0 operator:seed
> mkdir -p .tmp/operator && npx tsc scripts/seed-operator.ts --target ES2022 --module commonjs --moduleResolution node --esModuleInterop --skipLibCheck --outDir .tmp/operator && node .tmp/operator/seed-operator.js
- 
> service-butler-ai@0.1.0 operator-test
> node scripts/operator-test.mjs

[operator-test] mode=live-partially-configured
[operator-test] config-note: PERMITS_PROVIDER_URL not set (connector will run in synthetic mode)
[operator-test] config-note: Inngest keys missing

## UI Impact
- No UI changes in this PR.
- Operator-facing impact is in activation clarity: setup failures now return explicit remediation for local Supabase, webhook secrets, app URL, memberships, and Inngest readiness.
