### PR TITLE
Add non-blocking PR smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,30 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  e2e-smoke:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install
+        run: npm install
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Smoke E2E
+        run: npm run test:e2e -- tests/smoke-home-login.spec.ts tests/smoke-dashboard-entry.spec.ts tests/smoke-demo-lead-to-schedule.spec.ts
+        env:
+          PLAYWRIGHT_START_SERVER: "true"
+          DEMO_MODE: "true"
+          ALLOW_NON_DEV_DEMO_MODE: "true"

--- a/tests/smoke-demo-lead-to-schedule.spec.ts
+++ b/tests/smoke-demo-lead-to-schedule.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "@playwright/test";
+
+test("demo smoke: lead inbox to job conversion and schedule board", async ({ page }) => {
+  await page.goto("/dashboard/leads");
+
+  await expect(page.getByRole("heading", { name: "Lead Inbox" })).toBeVisible();
+
+  const leadCard = page.locator("article").filter({ hasText: "Sarah Parker" }).first();
+  await expect(leadCard).toBeVisible();
+  await leadCard.getByRole("link", { name: /^Open$/ }).click();
+
+  await expect(page).toHaveURL(/\/dashboard\/leads\/lead-demo-1$/);
+  await expect(page.getByRole("button", { name: /Convert to Job|Open Job/i }).first()).toBeVisible();
+
+  await page.getByRole("button", { name: /Convert to Job|Open Job/i }).first().click();
+  await expect(page).toHaveURL(/\/dashboard\/jobs\/job-demo-1$/);
+
+  await page.goto("/dashboard/schedule");
+  await expect(page).toHaveURL(/\/dashboard\/schedule/);
+  await expect(page.getByRole("heading", { name: "Schedule", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Upcoming Scheduled Leads" })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- recover the useful CI smoke intent from stale PR #25
- add a non-blocking pull-request smoke job to the main CI workflow
- include the current demo smoke flow test so PRs get lightweight browser coverage

## Validation
- npm test -- tests/smoke-home-login.spec.ts tests/smoke-dashboard-entry.spec.ts tests/smoke-demo-lead-to-schedule.spec.ts

## Notes
- intended to supersede the CI-smoke portion of #25
- job is continue-on-error so it provides signal without blocking merges