### PR TITLE
Align marketing pages with franchise source structure

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -11,39 +11,53 @@ const tiers = [
     name: "Starter",
     price: "$99",
     period: "/month",
-    description: "For owner-operators validating local demand intelligence.",
+    description: "Perfect for independent contractors getting started with lead intelligence.",
     badge: null,
     features: [
       "Up to 2 territories",
-      "Core scanner and pipeline views",
-      "Data source health and readiness checks",
-      "Basic lead and workflow tracking"
+      "100 opportunities/month",
+      "AI lead scoring",
+      "Email outreach",
+      "Basic analytics",
+      "Weather alert monitoring",
+      "Community support"
     ]
   },
   {
     name: "Pro",
     price: "$299",
     period: "/month",
-    description: "For growth teams running multi-channel capture and conversion workflows.",
+    description: "For growing companies that need territory management and advanced automation.",
     badge: "Most Popular",
     features: [
       "Up to 10 territories",
-      "Expanded source and connector controls",
-      "Operator-grade outbound and routing workflows",
-      "Advanced dashboard and opportunity intelligence"
+      "Unlimited opportunities",
+      "AI lead scoring & enrichment",
+      "Multi-channel outreach (email, SMS, calls)",
+      "Catastrophe response automation",
+      "Territory routing & assignment",
+      "Advanced analytics & reporting",
+      "CRM integrations",
+      "Priority support"
     ]
   },
   {
     name: "Enterprise",
-    price: "Custom",
-    period: "",
-    description: "For franchise operators and multi-market organizations with strict controls.",
+    price: "$799",
+    period: "/month",
+    description: "For franchise operators managing large multi-location operations.",
     badge: null,
     features: [
-      "Unlimited territories and operator seats",
-      "Network and buyer-proof readiness surfaces",
-      "Custom onboarding and rollout support",
-      "Tenant and compliance policy alignment"
+      "Unlimited territories",
+      "Unlimited opportunities",
+      "Everything in Pro",
+      "Custom data source integrations",
+      "API access",
+      "Role-based access control",
+      "Overflow routing & surge pricing",
+      "Dedicated account manager",
+      "Custom onboarding & training",
+      "SLA guarantee"
     ]
   }
 ] as const;
@@ -56,9 +70,9 @@ export default function PricingPage() {
         <section className="page-section py-16">
           <div className="container text-center">
             <p className="eyebrow justify-center">Pricing</p>
-            <h1 className="title-hero mx-auto mt-6 max-w-4xl text-semantic-text">Transparent plans for every stage of operator maturity.</h1>
+            <h1 className="title-hero mx-auto mt-6 max-w-4xl text-semantic-text">Simple, transparent pricing.</h1>
             <p className="text-body-lg mx-auto mt-4 max-w-3xl text-semantic-muted">
-              Start with a pilot motion, then scale into multi-territory command and buyer-proof operations.
+              Start free for 14 days. No credit card required. Scale as your business grows.
             </p>
           </div>
         </section>
@@ -84,7 +98,7 @@ export default function PricingPage() {
                 </ul>
                 <div className="mt-6">
                   <Link href="/login" className={buttonStyles({ fullWidth: true })}>
-                    {tier.name === "Enterprise" ? "Contact Sales" : "Try Demo"}
+                    {tier.name === "Enterprise" ? "Contact Sales" : "Start Free Trial"}
                     <ArrowRight className="h-4 w-4" />
                   </Link>
                 </div>
@@ -99,16 +113,20 @@ export default function PricingPage() {
             <div className="mt-8 space-y-6">
               {[
                 {
-                  q: "Can we change plans as we grow?",
-                  a: "Yes. Plans can be upgraded as your territory footprint and operator workflow needs expand."
+                  q: "Can I change plans later?",
+                  a: "Yes, you can upgrade or downgrade at any time. Changes take effect at your next billing cycle."
                 },
                 {
-                  q: "What counts as a live source?",
-                  a: "A source counts as live when terms and compliance are approved, credentials are configured, and runtime mode is not simulated."
+                  q: "What counts as an opportunity?",
+                  a: "An opportunity is any lead signal detected from your connected data sources, weather alerts, permit data, or manual entries."
                 },
                 {
-                  q: "Do you support pilot onboarding?",
-                  a: "Yes. Service Butler supports pilot activation with source readiness checks and operator runbooks."
+                  q: "Do you offer annual discounts?",
+                  a: "Yes. Annual pricing can be structured for larger rollouts and enterprise plans."
+                },
+                {
+                  q: "Is there a free trial?",
+                  a: "Every plan includes a 14-day free trial with full access. No credit card is required to get started."
                 }
               ].map((faq) => (
                 <div key={faq.q}>

--- a/src/app/product/page.tsx
+++ b/src/app/product/page.tsx
@@ -10,32 +10,32 @@ const capabilities = [
     icon: Radar,
     title: "Signal Intelligence",
     description:
-      "Weather, permits, municipal incidents, and public distress signals feed one operator view so demand is visible before competitors react."
+      "Our AI scans weather APIs, municipal permits, public incidents, and local demand signals to identify high-intent property-service opportunities before competitors react."
   },
   {
     icon: Database,
     title: "Lead Enrichment",
-    description: "Signals are normalized with service fit, confidence, and provenance so dispatch works from context instead of raw noise."
+    description: "Every signal is enriched with service fit, contact context, source provenance, and urgency scoring so operators work actionable leads instead of raw noise."
   },
   {
     icon: Route,
     title: "Smart Routing",
-    description: "Opportunities route by territory and service line while preserving compliance, suppression, and audit controls."
+    description: "Leads route to the right territory and service line with operator controls, overflow handling, and audit-safe workflow rules."
   },
   {
     icon: Bell,
-    title: "Coordinated Outreach",
-    description: "Operators launch outreach with safeguards, channel readiness checks, and tenant-scoped guardrails."
+    title: "Automated Outreach",
+    description: "Trigger email, SMS, and operator follow-up sequences with channel safeguards, safe mode, and tenant-scoped controls."
   },
   {
     icon: MapPin,
     title: "Command Center",
-    description: "Dashboard surfaces scanner, pipeline, jobs, and source health so teams can move from incident to booked work quickly."
+    description: "A live operations view for opportunities, lead status, routing context, and source health so teams can move from signal to booked work quickly."
   },
   {
     icon: Shield,
-    title: "Trust Controls",
-    description: "Buyer-proof capture status, compliance policy, and source provenance are visible across the workflow."
+    title: "Catastrophe Mode",
+    description: "When severe events hit, operators can shift into surge workflows with stronger prioritization, territory support, and visible readiness controls."
   }
 ] as const;
 
@@ -47,9 +47,9 @@ export default function ProductPage() {
         <section className="page-section py-16">
           <div className="container text-center">
             <p className="eyebrow justify-center">Product</p>
-            <h1 className="title-hero mx-auto mt-6 max-w-4xl text-semantic-text">How Service Butler turns market signals into booked jobs.</h1>
+            <h1 className="title-hero mx-auto mt-6 max-w-4xl text-semantic-text">How Service Butler finds you more jobs.</h1>
             <p className="text-body-lg mx-auto mt-4 max-w-3xl text-semantic-muted">
-              The platform combines acquisition-ready data sources, operator workflows, and proof-safe automation for restoration and home-service teams.
+              From signal detection to booked revenue, Service Butler automates the restoration and home-service lead pipeline with operator-grade control.
             </p>
           </div>
         </section>
@@ -59,10 +59,10 @@ export default function ProductPage() {
             <h2 className="section-title text-center text-semantic-text">How it works</h2>
             <div className="mt-8 grid gap-4 lg:grid-cols-4">
               {[
-                { step: "1", title: "Detect", desc: "Connectors pull weather, permits, incidents, and public distress data." },
-                { step: "2", title: "Normalize", desc: "Signals become ranked opportunities with provenance and confidence." },
-                { step: "3", title: "Route", desc: "Opportunities map into service-line and territory workflows." },
-                { step: "4", title: "Convert", desc: "Dispatch and outreach move qualified demand into scheduled work." }
+                { step: "1", title: "Detect", desc: "AI scans weather, public incidents, and permit sources around the clock." },
+                { step: "2", title: "Enrich", desc: "Opportunities are scored and enriched with contact and property context." },
+                { step: "3", title: "Route", desc: "Matched to the right territory and assigned into your operator workflow." },
+                { step: "4", title: "Convert", desc: "Outreach and dispatch actions move leads into booked jobs." }
               ].map((item) => (
                 <Card key={item.step} className="rounded-2xl border-semantic-border p-5 text-center">
                   <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-brand-700 text-sm font-semibold text-white">{item.step}</div>
@@ -77,6 +77,9 @@ export default function ProductPage() {
         <section className="page-section py-14">
           <div className="container">
             <h2 className="section-title text-center text-semantic-text">Platform capabilities</h2>
+            <p className="text-body-lg mx-auto mt-4 max-w-3xl text-center text-semantic-muted">
+              Every tool you need to capture, manage, and convert restoration opportunities at scale.
+            </p>
             <div className="mt-8 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
               {capabilities.map((capability) => (
                 <Card key={capability.title} className="rounded-2xl border-semantic-border p-5">
@@ -93,16 +96,16 @@ export default function ProductPage() {
 
         <section className="page-section bg-[rgb(var(--sb-text))] py-12 text-white">
           <div className="container text-center">
-            <h2 className="section-title text-white">See the operator workflow live</h2>
+            <h2 className="section-title text-white">See it in action</h2>
             <p className="mx-auto mt-3 max-w-2xl text-base text-white/80">
-              Walk through scanner, source health, lead routing, and pipeline execution in one demo.
+              Start a demo and see how opportunities move from live signals to booked work in one command center.
             </p>
             <div className="mt-6 flex flex-wrap justify-center gap-3">
               <Link href="/login" className={buttonStyles({ size: "lg", variant: "secondary", className: "border-white/20 bg-white/10 text-white hover:bg-white/20" })}>
                 Try Demo
               </Link>
               <Link href="/pricing" className={buttonStyles({ size: "lg", className: "bg-white text-[rgb(var(--sb-text))] hover:bg-white/90" })}>
-                View Pricing
+                Get Started
                 <ArrowRight className="h-4 w-4" />
               </Link>
             </div>

--- a/src/app/solutions/page.tsx
+++ b/src/app/solutions/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, Building2, CheckCircle2, CloudLightning, Droplets, Flame, Wrench } from "lucide-react";
+import { ArrowRight, Building2, CheckCircle2, CloudLightning, Droplets, Flame, Bug, Wrench } from "lucide-react";
 import { Footer } from "@/components/brand/Footer";
 import { TopNav } from "@/components/brand/TopNav";
 import { buttonStyles } from "@/components/ui/button";
@@ -8,39 +8,39 @@ import { Card } from "@/components/ui/card";
 const solutions = [
   {
     icon: Droplets,
-    title: "Water Damage Response",
-    description: "Track flood and water-loss patterns so dispatch can react before claims and referral loops saturate.",
-    benefits: ["Flood and weather overlap signals", "Water mitigation intent scoring", "Provenance-backed operator queue"]
+    title: "Water Damage Restoration",
+    description: "Monitor flood zones, pipe burst reports, and water-loss signals so teams can react the moment damage appears in territory.",
+    benefits: ["Flood alert integration", "Water mitigation intent scoring", "Plumbing emergency overlap"]
   },
   {
     icon: Flame,
-    title: "Fire and Smoke Restoration",
-    description: "Surface fire-adjacent incidents and urgency indicators with auditable source evidence.",
-    benefits: ["Incident lane coverage", "Catastrophe readiness context", "Faster triage to inspection workflows"]
+    title: "Fire Damage Restoration",
+    description: "Track fire-adjacent incidents and urgency signals so operators can move fast after a major property event.",
+    benefits: ["Fire incident detection", "Smoke damage lead scoring", "Rapid-response triage workflows"]
+  },
+  {
+    icon: Bug,
+    title: "Mold Remediation",
+    description: "Identify moisture and mold-related demand using post-flood patterns, public health indicators, and property risk context.",
+    benefits: ["Moisture risk scoring", "Post-flood mold detection", "Inspection-driven routing context"]
   },
   {
     icon: CloudLightning,
-    title: "Storm and Catastrophe",
-    description: "Use weather-driven surge detection to prioritize high-impact territories when severe events hit.",
-    benefits: ["NOAA and disaster context", "Territory-aware prioritization", "Outage and storm response support"]
+    title: "Storm Restoration",
+    description: "When severe weather hits, move into surge mode with stronger prioritization, overflow support, and territory-level response.",
+    benefits: ["Storm tracking context", "Hail and wind damage mapping", "Surge capacity management"]
   },
   {
     icon: Building2,
-    title: "Commercial Property Signals",
-    description: "Identify commercial facilities with risk and incident overlap to guide high-value outreach.",
-    benefits: ["Property signal enrichment", "Market-risk overlays", "Service-line fit scoring"]
+    title: "Commercial Restoration",
+    description: "Track commercial properties with permits, incidents, and facility risk overlap to support higher-value jobs.",
+    benefits: ["Commercial property monitoring", "Facility outreach context", "High-value job scoring"]
   },
   {
     icon: Wrench,
-    title: "Home Services Expansion",
-    description: "Extend incident and distress coverage into plumbing, HVAC, and outage-driven demand.",
-    benefits: ["Utility outage ingestion", "HVAC and plumbing routing", "Mixed-service operator visibility"]
-  },
-  {
-    icon: CheckCircle2,
-    title: "Buyer-Proof Operations",
-    description: "Expose what is live, blocked, or simulated so teams can trust what counts toward real revenue proof.",
-    benefits: ["Capture-status transparency", "Compliance and terms visibility", "Rollout-safe environment gating"]
+    title: "Home Services & HVAC",
+    description: "Expand beyond restoration into plumbing, HVAC, electrical, and outage-driven demand from the same command platform.",
+    benefits: ["HVAC failure detection", "Utility outage ingestion", "Seasonal demand forecasting"]
   }
 ] as const;
 
@@ -52,9 +52,9 @@ export default function SolutionsPage() {
         <section className="page-section py-16">
           <div className="container text-center">
             <p className="eyebrow justify-center">Solutions</p>
-            <h1 className="title-hero mx-auto mt-6 max-w-4xl text-semantic-text">Built for restoration and home-service operators who need reliable demand flow.</h1>
+            <h1 className="title-hero mx-auto mt-6 max-w-4xl text-semantic-text">Solutions for every service line.</h1>
             <p className="text-body-lg mx-auto mt-4 max-w-3xl text-semantic-muted">
-              Service Butler supports single-market teams and multi-territory franchises with the same operator-grade control plane.
+              Whether you run a single territory or a multi-state franchise, Service Butler adapts to your service specialties.
             </p>
           </div>
         </section>
@@ -82,27 +82,49 @@ export default function SolutionsPage() {
         </section>
 
         <section className="page-section border-y border-semantic-border/70 bg-white/72 py-12">
+          <div className="container">
+            <h2 className="section-title text-center text-semantic-text">Built for both audiences</h2>
+          </div>
           <div className="container grid gap-4 md:grid-cols-2">
             <Card className="rounded-2xl border-semantic-border p-6">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-brand-700">Independent teams</p>
-              <p className="mt-3 text-base font-semibold text-semantic-text">Launch quickly and prioritize local jobs with confidence.</p>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-brand-700">Independent contractors</p>
+              <p className="mt-3 text-base font-semibold text-semantic-text">Stop relying on referrals alone.</p>
               <p className="mt-2 text-sm leading-7 text-semantic-muted">
-                Start with core sources, run scanner daily, and convert high-intent opportunities into scheduled inspections.
+                Service Butler gives solo operators and small teams a steady stream of high-intent opportunities in their service area.
               </p>
+              <ul className="mt-4 space-y-2 text-sm text-semantic-text">
+                {["Affordable Starter plan", "Easy setup", "AI does the prospecting for you"].map((item) => (
+                  <li key={item} className="flex gap-2">
+                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-brand-700" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
             </Card>
             <Card className="rounded-2xl border-semantic-border p-6">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-brand-700">Franchise networks</p>
-              <p className="mt-3 text-base font-semibold text-semantic-text">Coordinate territory coverage, readiness, and surge response from one command center.</p>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-brand-700">Franchise operators</p>
+              <p className="mt-3 text-base font-semibold text-semantic-text">Run distributed territory operations from one command center.</p>
               <p className="mt-2 text-sm leading-7 text-semantic-muted">
-                Use connector truth, compliance gates, and operational dashboards to keep distributed teams aligned.
+                Centralized lead routing, catastrophe response, and operational visibility help larger networks stay aligned.
               </p>
+              <ul className="mt-4 space-y-2 text-sm text-semantic-text">
+                {["Unlimited territory management", "Role-based team access", "Enterprise onboarding support"].map((item) => (
+                  <li key={item} className="flex gap-2">
+                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-brand-700" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
             </Card>
           </div>
         </section>
 
         <section className="page-section py-12">
           <div className="container text-center">
-            <h2 className="section-title text-semantic-text">Choose the rollout path that fits your operation.</h2>
+            <h2 className="section-title text-semantic-text">Find your perfect fit.</h2>
+            <p className="mx-auto mt-3 max-w-2xl text-base text-semantic-muted">
+              Pick the plan that matches your business and rollout stage.
+            </p>
             <div className="mt-6 flex flex-wrap justify-center gap-3">
               <Link href="/pricing" className={buttonStyles({ size: "lg" })}>
                 View Pricing


### PR DESCRIPTION
## Summary
- bring , , and  closer to the original  marketing page structure
- preserve the Service Butler Next.js shell, routes, and brand components
- keep copy slightly grounded where needed while restoring the original section flow, service-line framing, and pricing pattern

## Source reference
- 
- 
- 

## Validation
- npm run typecheck
- npm run build

## Notes
- this intentionally does not touch the unrelated  local change
- this is a marketing-only parity pass