### PR TITLE
Runtime closure: watchdog scheduling + idempotency/replay propagation

### DIFF
--- a/src/app/api/agents/sdr/run/route.ts
+++ b/src/app/api/agents/sdr/run/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { assertRole } from "@/lib/auth/rbac";
 import { featureFlags } from "@/lib/config/feature-flags";
 import { isDemoMode } from "@/lib/services/review-mode";
+import { buildConnectorRunIdempotencyKey } from "@/lib/v2/connector-run-request";
 import { getV2TenantContext } from "@/lib/v2/context";
 import { runSdrAgentV2 } from "@/lib/v2/sdr-agent";
 import type { AccountRole } from "@/types/domain";
@@ -37,6 +38,7 @@ export async function POST(req: NextRequest) {
     enableEnrichment?: boolean;
     dryRun?: boolean;
     dualWriteLegacy?: boolean;
+    idempotencyKey?: string;
   };
 
   try {
@@ -58,7 +60,17 @@ export async function POST(req: NextRequest) {
       autoOutreach: body.autoOutreach ?? false,
       enableEnrichment: body.enableEnrichment ?? true,
       dryRun: body.dryRun ?? false,
-      dualWriteLegacy: body.dualWriteLegacy ?? true
+      dualWriteLegacy: body.dualWriteLegacy ?? true,
+      connectorRunIdempotencyPrefix:
+        String(body.idempotencyKey || "").trim() ||
+        req.headers.get("x-idempotency-key") ||
+        buildConnectorRunIdempotencyKey({
+          entrypoint: "api_agents_sdr_run",
+          tenantId: context.franchiseTenantId,
+          sourceId: "multi-source",
+          connectorKey: "sdr-agent",
+          requestedAt: req.headers.get("x-requested-at")
+        })
     });
 
     return NextResponse.json({ ok: true, result });
@@ -67,4 +79,3 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: message }, { status: 400 });
   }
 }
-

--- a/src/app/api/connectors/runs/route.ts
+++ b/src/app/api/connectors/runs/route.ts
@@ -5,6 +5,7 @@ import { featureFlags } from "@/lib/config/feature-flags";
 import { getV2TenantContext } from "@/lib/v2/context";
 import { getConnectorByKey } from "@/lib/v2/connectors/registry";
 import { runConnectorForSource } from "@/lib/v2/connectors/runner";
+import { buildConnectorRunIdempotencyKey, normalizeConnectorRunMode } from "@/lib/v2/connector-run-request";
 import { inferConnectorKey } from "@/lib/v2/connectors/source-type-map";
 import { computeRuntimeMode } from "@/lib/control-plane/data-sources";
 import type { AccountRole } from "@/types/domain";
@@ -65,6 +66,9 @@ export async function POST(req: NextRequest) {
   const body = (await req.json().catch(() => ({}))) as {
     sourceId?: string;
     connectorKey?: string;
+    idempotencyKey?: string;
+    runMode?: string;
+    replayedFromRunId?: string;
   };
 
   let sources: Array<Record<string, unknown>> = [];
@@ -146,7 +150,19 @@ export async function POST(req: NextRequest) {
       sourceType: String(source.source_type || "unknown"),
       sourceConfig,
       actorUserId: context.userId,
-      connector
+      connector,
+      runMode: normalizeConnectorRunMode(body.runMode),
+      replayedFromRunId: String(body.replayedFromRunId || "").trim() || null,
+      idempotencyKey: buildConnectorRunIdempotencyKey({
+        entrypoint: "api_connectors_runs",
+        tenantId: context.franchiseTenantId,
+        sourceId: String(source.id),
+        connectorKey: connector.key,
+        runMode: normalizeConnectorRunMode(body.runMode),
+        replayedFromRunId: String(body.replayedFromRunId || "").trim() || null,
+        providedKey: String(body.idempotencyKey || "").trim() || req.headers.get("x-idempotency-key"),
+        requestedAt: req.headers.get("x-requested-at")
+      })
     });
 
     results.push({

--- a/src/app/api/data-sources/[id]/run/route.ts
+++ b/src/app/api/data-sources/[id]/run/route.ts
@@ -4,6 +4,7 @@ import { featureFlags } from "@/lib/config/feature-flags";
 import { buildDataSourceReadinessState, buildEnvironmentReadinessState } from "@/lib/control-plane/readiness";
 import { getDataSourceSummaryById } from "@/lib/control-plane/data-sources";
 import { isDemoMode } from "@/lib/services/review-mode";
+import { buildConnectorRunIdempotencyKey, normalizeConnectorRunMode } from "@/lib/v2/connector-run-request";
 import { runDataSourceConnector } from "@/lib/v2/data-sources";
 import { getV2TenantContext } from "@/lib/v2/context";
 import type { AccountRole } from "@/types/domain";
@@ -32,7 +33,12 @@ export async function POST(req: NextRequest, contextArg: { params: Promise<{ id:
   const sourceId = String(id || "").trim();
   if (!sourceId) return NextResponse.json({ error: "Source id is required" }, { status: 400 });
 
-  const body = (await req.json().catch(() => ({}))) as { connectorKey?: string };
+  const body = (await req.json().catch(() => ({}))) as {
+    connectorKey?: string;
+    idempotencyKey?: string;
+    runMode?: string;
+    replayedFromRunId?: string;
+  };
 
   try {
     const sourceSummary = await getDataSourceSummaryById({
@@ -62,7 +68,19 @@ export async function POST(req: NextRequest, contextArg: { params: Promise<{ id:
       tenantId: context.franchiseTenantId,
       sourceId,
       actorUserId: context.userId,
-      connectorKeyOverride: String(body.connectorKey || "").trim() || undefined
+      connectorKeyOverride: String(body.connectorKey || "").trim() || undefined,
+      runMode: normalizeConnectorRunMode(body.runMode),
+      replayedFromRunId: String(body.replayedFromRunId || "").trim() || null,
+      idempotencyKey: buildConnectorRunIdempotencyKey({
+        entrypoint: "api_data_source_run",
+        tenantId: context.franchiseTenantId,
+        sourceId,
+        connectorKey: String(body.connectorKey || "").trim() || sourceSummary.connectorKey,
+        runMode: normalizeConnectorRunMode(body.runMode),
+        replayedFromRunId: String(body.replayedFromRunId || "").trim() || null,
+        providedKey: String(body.idempotencyKey || "").trim() || req.headers.get("x-idempotency-key"),
+        requestedAt: req.headers.get("x-requested-at")
+      })
     });
 
     return NextResponse.json(result);

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -6,9 +6,9 @@ import {
   newLeadFollowup,
   reviewRequest
 } from "@/lib/workflows/functions";
-import { v2AssignmentSlaWatch, v2ConnectorRunRequested } from "@/lib/workflows/v2-functions";
+import { v2AssignmentSlaWatch, v2ConnectorRunRequested, v2ConnectorRunStaleWatchdog } from "@/lib/workflows/v2-functions";
 
 export const { GET, POST, PUT } = serve({
   client: inngest,
-  functions: [missedCallFollowup, newLeadFollowup, reviewRequest, campaignDispatch, v2ConnectorRunRequested, v2AssignmentSlaWatch]
+  functions: [missedCallFollowup, newLeadFollowup, reviewRequest, campaignDispatch, v2ConnectorRunRequested, v2AssignmentSlaWatch, v2ConnectorRunStaleWatchdog]
 });

--- a/src/lib/v2/connector-run-request.ts
+++ b/src/lib/v2/connector-run-request.ts
@@ -1,0 +1,60 @@
+export type ConnectorRunMode = "standard" | "replay";
+
+function asText(value: unknown) {
+  return String(value ?? "").trim();
+}
+
+export function normalizeConnectorRunMode(value: unknown): ConnectorRunMode {
+  const normalized = asText(value).toLowerCase();
+  return normalized === "replay" ? "replay" : "standard";
+}
+
+export function sanitizeIdempotencyKey(value: unknown) {
+  const raw = asText(value);
+  if (!raw) return "";
+  return raw.slice(0, 180);
+}
+
+function isoMinuteBucket(isoLike: unknown) {
+  const value = asText(isoLike);
+  const parsed = value ? new Date(value).toISOString() : new Date().toISOString();
+  return parsed.slice(0, 16);
+}
+
+export function buildConnectorRunIdempotencyKey({
+  entrypoint,
+  tenantId,
+  sourceId,
+  connectorKey,
+  runMode = "standard",
+  replayedFromRunId,
+  providedKey,
+  requestedAt
+}: {
+  entrypoint: string;
+  tenantId: string;
+  sourceId: string;
+  connectorKey: string;
+  runMode?: ConnectorRunMode;
+  replayedFromRunId?: string | null;
+  providedKey?: string | null;
+  requestedAt?: string | null;
+}) {
+  const explicit = sanitizeIdempotencyKey(providedKey);
+  if (explicit) return explicit;
+
+  const normalizedRunMode = normalizeConnectorRunMode(runMode);
+  const replayed = asText(replayedFromRunId);
+  const replaySuffix = replayed ? `:replay:${replayed}` : "";
+  const bucket = isoMinuteBucket(requestedAt);
+  const computed = [
+    asText(entrypoint) || "connector",
+    asText(tenantId) || "tenant",
+    asText(sourceId) || "source",
+    asText(connectorKey) || "connector",
+    normalizedRunMode,
+    bucket
+  ].join(":");
+
+  return sanitizeIdempotencyKey(`${computed}${replaySuffix}`);
+}

--- a/src/lib/v2/connectors/runner.ts
+++ b/src/lib/v2/connectors/runner.ts
@@ -2,11 +2,10 @@ import { checkOpportunityDuplicate, injectDedupKey } from "@/lib/v2/deduplicatio
 import { type FranchiseVertical, getVertical } from "@/lib/v2/franchise-verticals";
 import { computeOpportunityScores } from "@/lib/v2/scoring";
 import type { V2ConnectorRunResult } from "@/lib/v2/types";
+import { type ConnectorRunMode, normalizeConnectorRunMode, sanitizeIdempotencyKey } from "@/lib/v2/connector-run-request";
 import type { ConnectorAdapter, ConnectorNormalizedEvent, ConnectorPullInput } from "@/lib/v2/connectors/types";
 import { logV2AuditEvent } from "@/lib/v2/audit";
 import type { SupabaseClient } from "@supabase/supabase-js";
-
-type ConnectorRunMode = "standard" | "replay";
 
 function toPoint(lat?: number | null, lon?: number | null) {
   if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
@@ -259,6 +258,8 @@ function validateNormalizedEvent(event: ConnectorNormalizedEvent) {
 function normalizeRunResultStatus(value: unknown): V2ConnectorRunResult["status"] | null {
   const normalized = String(value || "").trim().toLowerCase();
   if (
+    normalized === "queued" ||
+    normalized === "running" ||
     normalized === "completed" ||
     normalized === "failed" ||
     normalized === "partial" ||
@@ -726,6 +727,10 @@ export async function runConnectorForSource({
   replayedFromRunId?: string | null;
   idempotencyKey?: string | null;
 }): Promise<V2ConnectorRunResult & { runId: string }> {
+  const normalizedRunMode = normalizeConnectorRunMode(runMode);
+  const normalizedReplaySource = String(replayedFromRunId || "").trim() || null;
+  const normalizedIdempotencyKey = sanitizeIdempotencyKey(idempotencyKey) || null;
+
   const runStart = new Date().toISOString();
   const { data: runRow, error: runError } = await supabase
     .from("v2_connector_runs")
@@ -735,26 +740,26 @@ export async function runConnectorForSource({
       status: "running",
       started_at: runStart,
       heartbeat_at: runStart,
-      idempotency_key: idempotencyKey,
-      replayed_from_run_id: replayedFromRunId,
+      idempotency_key: normalizedIdempotencyKey,
+      replayed_from_run_id: normalizedReplaySource,
       metadata: {
         connector_key: connector.key,
         source_type: sourceType,
-        run_mode: runMode,
-        replayed_from_run_id: replayedFromRunId
+        run_mode: normalizedRunMode,
+        replayed_from_run_id: normalizedReplaySource
       }
     })
     .select("id")
     .single();
 
   if (runError || !runRow?.id) {
-    if ((runError as { code?: string } | null)?.code === "23505" && idempotencyKey) {
+    if ((runError as { code?: string } | null)?.code === "23505" && normalizedIdempotencyKey) {
       const { data: existingRun, error: existingRunError } = await supabase
         .from("v2_connector_runs")
-        .select("id,status,records_seen,records_created,error_summary")
+        .select("id,status,records_seen,records_created,error_summary,idempotency_key,replayed_from_run_id,metadata")
         .eq("tenant_id", tenantId)
         .eq("source_id", sourceId)
-        .eq("idempotency_key", idempotencyKey)
+        .eq("idempotency_key", normalizedIdempotencyKey)
         .order("started_at", { ascending: false })
         .limit(1)
         .maybeSingle();
@@ -766,6 +771,9 @@ export async function runConnectorForSource({
           status,
           recordsSeen: Number(existingRun.records_seen || 0),
           recordsCreated: Number(existingRun.records_created || 0),
+          idempotencyKey: String(existingRun.idempotency_key || normalizedIdempotencyKey || ""),
+          replayedFromRunId: existingRun.replayed_from_run_id ? String(existingRun.replayed_from_run_id) : null,
+          runMode: String((existingRun.metadata as Record<string, unknown> | null)?.run_mode || normalizedRunMode) === "replay" ? "replay" : "standard",
           errorSummary: String(existingRun.error_summary || "")
         };
       }
@@ -907,7 +915,7 @@ export async function runConnectorForSource({
     await touchRunHeartbeat({ supabase, runId });
 
     const baseStatus = createdCount === normalizedEvents.length ? "completed" : "partial";
-    const status: V2ConnectorRunResult["status"] = runMode === "replay" ? "replayed" : baseStatus;
+    const status: V2ConnectorRunResult["status"] = normalizedRunMode === "replay" ? "replayed" : baseStatus;
     await supabase
       .from("v2_connector_runs")
       .update({
@@ -919,14 +927,15 @@ export async function runConnectorForSource({
         metadata: {
           connector_key: connector.key,
           source_type: sourceType,
-          run_mode: runMode,
-          replayed_from_run_id: replayedFromRunId,
+          run_mode: normalizedRunMode,
+          replayed_from_run_id: normalizedReplaySource,
           terms_status: compliance.termsStatus,
           avg_data_freshness_score: recordsSeen > 0 ? Math.round(totalFreshness / recordsSeen) : 0,
           avg_source_reliability: recordsSeen > 0 ? Math.round(totalReliability / recordsSeen) : 0,
           invalid_events: invalidCount,
           multi_signal_opportunities: multiSignalCount,
-          replay_result_status: baseStatus
+          replay_result_status: baseStatus,
+          idempotency_key: normalizedIdempotencyKey
         }
       })
       .eq("id", runId);
@@ -946,7 +955,8 @@ export async function runConnectorForSource({
         records_created: createdCount,
         invalid_events: invalidCount,
         multi_signal_opportunities: multiSignalCount,
-        run_mode: runMode
+        run_mode: normalizedRunMode,
+        idempotency_key: normalizedIdempotencyKey
       }
     });
 
@@ -954,7 +964,10 @@ export async function runConnectorForSource({
       runId,
       recordsSeen,
       recordsCreated: createdCount,
-      status
+      status,
+      runMode: normalizedRunMode,
+      replayedFromRunId: normalizedReplaySource,
+      idempotencyKey: normalizedIdempotencyKey
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown connector run failure";
@@ -986,6 +999,9 @@ export async function runConnectorForSource({
       recordsSeen,
       recordsCreated: createdCount,
       status: "failed",
+      runMode: normalizedRunMode,
+      replayedFromRunId: normalizedReplaySource,
+      idempotencyKey: normalizedIdempotencyKey,
       errorSummary: message
     };
   }

--- a/src/lib/v2/data-sources.ts
+++ b/src/lib/v2/data-sources.ts
@@ -2,6 +2,7 @@ import { getConnectorByKey, listConnectors } from "@/lib/v2/connectors/registry"
 import { inferConnectorKey } from "@/lib/v2/connectors/source-type-map";
 import type { ConnectorAdapter, ConnectorHealth, ConnectorPullInput } from "@/lib/v2/connectors/types";
 import { runConnectorForSource } from "@/lib/v2/connectors/runner";
+import { buildConnectorRunIdempotencyKey, normalizeConnectorRunMode, type ConnectorRunMode } from "@/lib/v2/connector-run-request";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 export type DataSourceRuntimeMode = "fully-live" | "live-partial" | "simulated";
@@ -546,13 +547,19 @@ export async function runDataSourceConnector({
   tenantId,
   sourceId,
   actorUserId,
-  connectorKeyOverride
+  connectorKeyOverride,
+  idempotencyKey,
+  runMode,
+  replayedFromRunId
 }: {
   supabase: SupabaseClient;
   tenantId: string;
   sourceId: string;
   actorUserId: string;
   connectorKeyOverride?: string;
+  idempotencyKey?: string;
+  runMode?: ConnectorRunMode;
+  replayedFromRunId?: string | null;
 }) {
   const sourceRow = await fetchDataSourceRow({ supabase, tenantId, sourceId });
   if (normalizeStatus(sourceRow.status) !== "active") {
@@ -587,7 +594,18 @@ export async function runDataSourceConnector({
     sourceType: String(sourceRow.source_type || "unknown"),
     sourceConfig: connectorConfig.input.config,
     actorUserId,
-    connector
+    connector,
+    runMode: normalizeConnectorRunMode(runMode),
+    replayedFromRunId: replayedFromRunId ? String(replayedFromRunId) : null,
+    idempotencyKey: buildConnectorRunIdempotencyKey({
+      entrypoint: "lib_v2_data_sources",
+      tenantId,
+      sourceId,
+      connectorKey: connector.key,
+      runMode,
+      replayedFromRunId,
+      providedKey: idempotencyKey
+    })
   });
 
   const sourceSummary = await getDataSourceSummary({ supabase, tenantId, sourceId });

--- a/src/lib/v2/runtime-watchdog.ts
+++ b/src/lib/v2/runtime-watchdog.ts
@@ -1,0 +1,24 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export function resolveStaleAfterMinutes(value: unknown, fallback = 45) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return Math.max(5, Math.round(fallback));
+  return Math.max(5, Math.round(parsed));
+}
+
+export async function markStaleConnectorRuns({
+  supabase,
+  staleAfterMinutes
+}: {
+  supabase: SupabaseClient;
+  staleAfterMinutes?: number;
+}) {
+  const threshold = resolveStaleAfterMinutes(staleAfterMinutes, 45);
+  const { data, error } = await supabase.rpc("mark_stale_connector_runs", {
+    p_stale_after_minutes: threshold
+  });
+
+  if (error) throw new Error(error.message || "Could not mark stale connector runs");
+  const marked = Number(data || 0);
+  return Number.isFinite(marked) ? marked : 0;
+}

--- a/src/lib/v2/sdr-agent.ts
+++ b/src/lib/v2/sdr-agent.ts
@@ -1,5 +1,6 @@
 import { enrichOpportunityLive } from "@/lib/services/enrichment";
 import { logV2AuditEvent } from "@/lib/v2/audit";
+import { buildConnectorRunIdempotencyKey } from "@/lib/v2/connector-run-request";
 import { getConnectorByKey } from "@/lib/v2/connectors/registry";
 import { runConnectorForSource } from "@/lib/v2/connectors/runner";
 import { inferConnectorKey } from "@/lib/v2/connectors/source-type-map";
@@ -63,6 +64,7 @@ export type SdrAgentRunOptions = {
   dryRun?: boolean;
   legacyAccountId?: string | null;
   dualWriteLegacy?: boolean;
+  connectorRunIdempotencyPrefix?: string;
 };
 
 export type SdrAgentRunResult = {
@@ -307,12 +309,14 @@ async function runSourceConnectors({
   supabase,
   tenantId,
   actorUserId,
-  sources
+  sources,
+  idempotencyPrefix
 }: {
   supabase: SupabaseClient;
   tenantId: string;
   actorUserId: string;
   sources: Array<Record<string, unknown>>;
+  idempotencyPrefix: string;
 }): Promise<SdrSourceRunResult[]> {
   const results: SdrSourceRunResult[] = [];
 
@@ -370,7 +374,14 @@ async function runSourceConnectors({
       sourceType,
       sourceConfig,
       actorUserId,
-      connector
+      connector,
+      idempotencyKey: buildConnectorRunIdempotencyKey({
+        entrypoint: "sdr_agent_connectors",
+        tenantId,
+        sourceId: String(source.id),
+        connectorKey,
+        providedKey: `${idempotencyPrefix}:${String(source.id)}`
+      })
     });
 
     results.push({
@@ -413,7 +424,8 @@ export async function runSdrAgentV2(options: SdrAgentRunOptions): Promise<SdrAge
     autoOutreach = false,
     enableEnrichment = true,
     dryRun = false,
-    dualWriteLegacy = true
+    dualWriteLegacy = true,
+    connectorRunIdempotencyPrefix = `sdr:${tenantId}:${new Date().toISOString().slice(0, 16)}`
   } = options;
 
   const enterpriseTenantId = toString(options.enterpriseTenantId) || tenantId;
@@ -432,7 +444,8 @@ export async function runSdrAgentV2(options: SdrAgentRunOptions): Promise<SdrAge
       supabase,
       tenantId,
       actorUserId,
-      sources
+      sources,
+      idempotencyPrefix: connectorRunIdempotencyPrefix
     });
     connectorRuns.push(...sourceRuns);
   }

--- a/src/lib/v2/types.ts
+++ b/src/lib/v2/types.ts
@@ -49,7 +49,10 @@ export type V2AssignmentDecision = {
 export type V2ConnectorRunResult = {
   recordsSeen: number;
   recordsCreated: number;
-  status: "completed" | "failed" | "partial" | "stale" | "replayed";
+  status: V2ConnectorRunStatus;
+  runMode?: "standard" | "replay";
+  replayedFromRunId?: string | null;
+  idempotencyKey?: string | null;
   errorSummary?: string;
 };
 

--- a/src/lib/workflows/v2-functions.ts
+++ b/src/lib/workflows/v2-functions.ts
@@ -1,19 +1,24 @@
 import { inngest } from "@/lib/workflows/client";
 import { getSupabaseAdminClient } from "@/lib/supabase/admin";
+import { buildConnectorRunIdempotencyKey, normalizeConnectorRunMode } from "@/lib/v2/connector-run-request";
 import { getConnectorByKey } from "@/lib/v2/connectors/registry";
 import { runConnectorForSource } from "@/lib/v2/connectors/runner";
 import { inferConnectorKey } from "@/lib/v2/connectors/source-type-map";
 import { logV2AuditEvent } from "@/lib/v2/audit";
+import { markStaleConnectorRuns, resolveStaleAfterMinutes } from "@/lib/v2/runtime-watchdog";
 
 export const v2ConnectorRunRequested = inngest.createFunction(
   { id: "v2_connector_run_requested" },
   { event: "v2/connector.run.requested" },
   async ({ event, step }) => {
-    const { tenantId, sourceId, connectorKey, actorUserId } = event.data as {
+    const { tenantId, sourceId, connectorKey, actorUserId, idempotencyKey, runMode, replayedFromRunId } = event.data as {
       tenantId: string;
       sourceId: string;
       connectorKey?: string;
       actorUserId?: string;
+      idempotencyKey?: string;
+      runMode?: string;
+      replayedFromRunId?: string;
     };
 
     const supabase = getSupabaseAdminClient();
@@ -48,7 +53,19 @@ export const v2ConnectorRunRequested = inngest.createFunction(
           config_encrypted: source.config_encrypted
         },
         actorUserId: actorUserId || "system",
-        connector
+        connector,
+        runMode: normalizeConnectorRunMode(runMode),
+        replayedFromRunId: String(replayedFromRunId || "").trim() || null,
+        idempotencyKey: buildConnectorRunIdempotencyKey({
+          entrypoint: "inngest_connector_run_requested",
+          tenantId,
+          sourceId: String(source.id),
+          connectorKey: key,
+          runMode: normalizeConnectorRunMode(runMode),
+          replayedFromRunId: String(replayedFromRunId || "").trim() || null,
+          providedKey: String(idempotencyKey || "").trim() || String((event as { id?: string } | null)?.id || ""),
+          requestedAt: String((event as { ts?: string } | null)?.ts || "")
+        })
       })
     );
 
@@ -56,6 +73,28 @@ export const v2ConnectorRunRequested = inngest.createFunction(
       ok: result.status !== "failed",
       ...result,
       connectorKey: key
+    };
+  }
+);
+
+export const v2ConnectorRunStaleWatchdog = inngest.createFunction(
+  { id: "v2_connector_run_stale_watchdog" },
+  { cron: "*/15 * * * *" },
+  async ({ step }) => {
+    const supabase = getSupabaseAdminClient();
+    const staleAfterMinutes = resolveStaleAfterMinutes(process.env.CONNECTOR_STALE_AFTER_MINUTES, 45);
+
+    const staleMarked = await step.run("mark-stale-connector-runs", async () =>
+      markStaleConnectorRuns({
+        supabase,
+        staleAfterMinutes
+      })
+    );
+
+    return {
+      ok: true,
+      staleMarked,
+      staleAfterMinutes
     };
   }
 );

--- a/tests/v2-runtime-closure.spec.ts
+++ b/tests/v2-runtime-closure.spec.ts
@@ -1,0 +1,266 @@
+import { expect, test } from "@playwright/test";
+import { runConnectorForSource } from "../src/lib/v2/connectors/runner";
+import { buildConnectorRunIdempotencyKey } from "../src/lib/v2/connector-run-request";
+import { markStaleConnectorRuns, resolveStaleAfterMinutes } from "../src/lib/v2/runtime-watchdog";
+
+test("duplicate trigger suppression returns existing run without coercing status", async () => {
+  const supabaseMock = {
+    from(table: string) {
+      if (table !== "v2_connector_runs") throw new Error(`Unexpected table ${table}`);
+      return {
+        insert: () => ({
+          select: () => ({
+            single: async () => ({ data: null, error: { code: "23505", message: "duplicate key" } })
+          })
+        }),
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              eq: () => ({
+                order: () => ({
+                  limit: () => ({
+                    maybeSingle: async () => ({
+                      data: {
+                        id: "run-existing-1",
+                        status: "running",
+                        records_seen: 9,
+                        records_created: 4,
+                        error_summary: "",
+                        idempotency_key: "dup-key",
+                        replayed_from_run_id: null,
+                        metadata: { run_mode: "standard" }
+                      },
+                      error: null
+                    })
+                  })
+                })
+              })
+            })
+          })
+        })
+      };
+    }
+  };
+
+  const result = await runConnectorForSource({
+    supabase: supabaseMock as never,
+    tenantId: "tenant-1",
+    sourceId: "source-1",
+    sourceType: "incident",
+    sourceConfig: {},
+    actorUserId: "user-1",
+    connector: {
+      key: "incident",
+      pull: async () => [],
+      normalize: async () => [],
+      classify: () => ({ opportunityType: "incident", serviceLine: "restoration" }),
+      dedupeKey: () => "dedupe",
+      compliancePolicy: () => ({ termsStatus: "approved", ingestionAllowed: true, outboundAllowed: false, requiresLegalReview: false }),
+      healthcheck: async () => ({ ok: true })
+    },
+    idempotencyKey: "dup-key"
+  });
+
+  expect(result.runId).toBe("run-existing-1");
+  expect(result.status).toBe("running");
+  expect(result.recordsSeen).toBe(9);
+  expect(result.recordsCreated).toBe(4);
+});
+
+test("replay run preserves lineage and marks terminal status replayed", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const previousServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+
+  const connectorRuns: Array<Record<string, unknown>> = [];
+  const runUpdates: Array<Record<string, unknown>> = [];
+
+  (globalThis as typeof globalThis & { fetch: typeof fetch }).fetch = async (input, init) => {
+    const url = String(input);
+    if (!url.includes("/rest/v1/v2_audit_logs")) throw new Error(`Unexpected fetch: ${url}`);
+    return new Response(JSON.stringify([{ id: "audit-1", payload: init?.body ? JSON.parse(String(init.body)) : {} }]), {
+      status: 201,
+      headers: { "content-type": "application/json" }
+    });
+  };
+
+  const supabaseMock = {
+    from(table: string) {
+      if (table === "v2_connector_runs") {
+        return {
+          insert: (payload: Record<string, unknown>) => ({
+            select: () => ({
+              single: async () => {
+                const row = { id: "run-replay-1", ...payload };
+                connectorRuns.push(row);
+                return { data: row, error: null };
+              }
+            })
+          }),
+          update: (patch: Record<string, unknown>) => ({
+            eq: async () => {
+              runUpdates.push(patch);
+              return { data: null, error: null };
+            }
+          })
+        };
+      }
+
+      if (table === "v2_tenants") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: { settings_json: { vertical: "restoration" } }, error: null })
+            })
+          })
+        };
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    }
+  };
+
+  try {
+    const result = await runConnectorForSource({
+      supabase: supabaseMock as never,
+      tenantId: "tenant-1",
+      sourceId: "source-1",
+      sourceType: "incident",
+      sourceConfig: {},
+      actorUserId: "user-1",
+      connector: {
+        key: "incident",
+        pull: async () => [],
+        normalize: async () => [],
+        classify: () => ({ opportunityType: "incident", serviceLine: "restoration" }),
+        dedupeKey: () => "dedupe",
+        compliancePolicy: () => ({ termsStatus: "approved", ingestionAllowed: true, outboundAllowed: false, requiresLegalReview: false }),
+        healthcheck: async () => ({ ok: true })
+      },
+      runMode: "replay",
+      replayedFromRunId: "run-original-1",
+      idempotencyKey: "replay-key-1"
+    });
+
+    expect(result.status).toBe("replayed");
+    expect(result.replayedFromRunId).toBe("run-original-1");
+    expect(result.idempotencyKey).toBe("replay-key-1");
+    expect(connectorRuns[0]?.replayed_from_run_id).toBe("run-original-1");
+    expect(connectorRuns[0]?.idempotency_key).toBe("replay-key-1");
+    expect((runUpdates[runUpdates.length - 1]?.metadata as Record<string, unknown>)?.replayed_from_run_id).toBe("run-original-1");
+  } finally {
+    (globalThis as typeof globalThis & { fetch: typeof fetch }).fetch = previousFetch;
+    if (previousSupabaseUrl === undefined) delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    else process.env.NEXT_PUBLIC_SUPABASE_URL = previousSupabaseUrl;
+    if (previousServiceRoleKey === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    else process.env.SUPABASE_SERVICE_ROLE_KEY = previousServiceRoleKey;
+  }
+});
+
+test("stale-run marking uses bounded threshold behavior", async () => {
+  expect(resolveStaleAfterMinutes(undefined, 45)).toBe(45);
+  expect(resolveStaleAfterMinutes(2, 45)).toBe(5);
+  expect(resolveStaleAfterMinutes(17.6, 45)).toBe(18);
+
+  const calls: Array<Record<string, unknown>> = [];
+  const supabaseMock = {
+    rpc: async (name: string, args: Record<string, unknown>) => {
+      calls.push({ name, ...args });
+      return { data: 3, error: null };
+    }
+  };
+
+  const marked = await markStaleConnectorRuns({
+    supabase: supabaseMock as never,
+    staleAfterMinutes: 3
+  });
+
+  expect(marked).toBe(3);
+  expect(calls[0]?.name).toBe("mark_stale_connector_runs");
+  expect(calls[0]?.p_stale_after_minutes).toBe(5);
+});
+
+test("legacy-compatible standard run remains completed and idempotency keys are stable", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const previousServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+
+  (globalThis as typeof globalThis & { fetch: typeof fetch }).fetch = async (input) => {
+    const url = String(input);
+    if (!url.includes("/rest/v1/v2_audit_logs")) throw new Error(`Unexpected fetch: ${url}`);
+    return new Response(JSON.stringify([{ id: "audit-compat-1" }]), {
+      status: 201,
+      headers: { "content-type": "application/json" }
+    });
+  };
+
+  const supabaseMock = {
+    from(table: string) {
+      if (table === "v2_connector_runs") {
+        return {
+          insert: () => ({
+            select: () => ({
+              single: async () => ({ data: { id: "run-standard-1" }, error: null })
+            })
+          }),
+          update: () => ({
+            eq: async () => ({ data: null, error: null })
+          })
+        };
+      }
+      if (table === "v2_tenants") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: { settings_json: {} }, error: null })
+            })
+          })
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    }
+  };
+
+  const key = buildConnectorRunIdempotencyKey({
+    entrypoint: "legacy_compat_check",
+    tenantId: "tenant-1",
+    sourceId: "source-1",
+    connectorKey: "incident",
+    providedKey: "legacy-fixed-key"
+  });
+  expect(key).toBe("legacy-fixed-key");
+
+  try {
+    const result = await runConnectorForSource({
+      supabase: supabaseMock as never,
+      tenantId: "tenant-1",
+      sourceId: "source-1",
+      sourceType: "incident",
+      sourceConfig: {},
+      actorUserId: "user-1",
+      connector: {
+        key: "incident",
+        pull: async () => [],
+        normalize: async () => [],
+        classify: () => ({ opportunityType: "incident", serviceLine: "restoration" }),
+        dedupeKey: () => "dedupe",
+        compliancePolicy: () => ({ termsStatus: "approved", ingestionAllowed: true, outboundAllowed: false, requiresLegalReview: false }),
+        healthcheck: async () => ({ ok: true })
+      },
+      idempotencyKey: key
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.runMode).toBe("standard");
+  } finally {
+    (globalThis as typeof globalThis & { fetch: typeof fetch }).fetch = previousFetch;
+    if (previousSupabaseUrl === undefined) delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    else process.env.NEXT_PUBLIC_SUPABASE_URL = previousSupabaseUrl;
+    if (previousServiceRoleKey === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    else process.env.SUPABASE_SERVICE_ROLE_KEY = previousServiceRoleKey;
+  }
+});


### PR DESCRIPTION
## Summary
- add scheduled stale-run watchdog execution via Inngest cron (`v2_connector_run_stale_watchdog`) using runtime watchdog helpers
- propagate idempotency keys and replay lineage through all connector run entrypoints:
  - `/api/connectors/runs`
  - `/api/data-sources/[id]/run`
  - `v2/connector.run.requested` workflow
  - SDR agent connector execution path
- enforce disciplined duplicate handling in connector runner by preserving existing `queued/running` statuses (no coercion to `partial`)
- add focused runtime tests for duplicate suppression, replay lineage, stale-threshold behavior, and standard-mode legacy compatibility

## Targeted Tests
- `npm run typecheck`
- `npm test -- tests/v2-runtime-closure.spec.ts tests/v2-firecrawl-incident-operator-flow.spec.ts`
- `npm run build`

## Risk Areas Reviewed
- status transition consistency in `runConnectorForSource` when duplicate idempotency keys race
- replay metadata continuity (`runMode`, `replayedFromRunId`, `idempotencyKey`) from API/workflow trigger to persisted run rows
- stale-run watchdog safety (bounded threshold and explicit `mark_stale_connector_runs` call path)
- legacy/v2 coexistence safety by preserving standard run terminal semantics (`completed/partial/failed`) and existing route contracts

## Scope Guardrails
- no new source connectors
- no broad product UX changes
- runtime closure only
