### PR TITLE
PR #39: source registry activation + Tier-1 incident hardening

### DIFF
--- a/src/app/api/connectors/runs/route.ts
+++ b/src/app/api/connectors/runs/route.ts
@@ -76,7 +76,7 @@ export async function POST(req: NextRequest) {
   if (body.sourceId) {
     const { data, error } = await context.supabase
       .from("v2_data_sources")
-      .select("id,source_type,name,config_encrypted,rate_limit_policy,compliance_flags,terms_status,provenance")
+      .select("id,source_type,name,config_encrypted,rate_limit_policy,compliance_flags,terms_status,compliance_status,rollout_state,provenance")
       .eq("tenant_id", context.franchiseTenantId)
       .eq("id", body.sourceId)
       .maybeSingle();
@@ -86,7 +86,7 @@ export async function POST(req: NextRequest) {
   } else {
     const { data, error } = await context.supabase
       .from("v2_data_sources")
-      .select("id,source_type,name,config_encrypted,rate_limit_policy,compliance_flags,terms_status,provenance")
+      .select("id,source_type,name,config_encrypted,rate_limit_policy,compliance_flags,terms_status,compliance_status,rollout_state,provenance")
       .eq("tenant_id", context.franchiseTenantId)
       .eq("status", "active")
       .limit(20);
@@ -105,9 +105,21 @@ export async function POST(req: NextRequest) {
       compliance_flags: source.compliance_flags,
       config_encrypted: source.config_encrypted,
       terms_status: source.terms_status,
+      compliance_status: source.compliance_status,
+      rollout_state: source.rollout_state,
       source_provenance: source.provenance,
       ...decryptedConfig
     };
+    const rolloutState = String(source.rollout_state || "pilot").toLowerCase();
+    if (rolloutState === "disabled" || rolloutState === "shadow") {
+      results.push({
+        sourceId: source.id,
+        status: "failed",
+        runtimeMode: rolloutState === "disabled" ? "simulated" : "live-partial",
+        error: `Source rollout_state=${rolloutState} blocks direct connector execution`
+      });
+      continue;
+    }
     const runtimeMode = computeRuntimeMode(
       String(source.source_type || "unknown"),
       sourceConfig,

--- a/src/app/api/data-sources/[id]/route.ts
+++ b/src/app/api/data-sources/[id]/route.ts
@@ -62,7 +62,9 @@ export async function PATCH(req: NextRequest, { params }: Params) {
       .update(payload)
       .eq("tenant_id", context.franchiseTenantId)
       .eq("id", sourceId)
-      .select("id,tenant_id,source_type,name,status,terms_status,provenance,reliability_score,freshness_timestamp,rate_limit_policy,compliance_flags,config_encrypted,compliance_status,created_at,updated_at")
+      .select(
+        "id,tenant_id,source_type,name,status,terms_status,compliance_status,rollout_state,readiness_status,provenance,reliability_score,freshness_timestamp,freshness_sla_minutes,health_status,health_detail,last_health_checked_at,last_health_latency_ms,rate_limit_policy,compliance_flags,config_encrypted,created_at,updated_at"
+      )
       .maybeSingle();
 
     if (error || !data?.id) {

--- a/src/lib/control-plane/data-sources.ts
+++ b/src/lib/control-plane/data-sources.ts
@@ -33,10 +33,18 @@ type RawSourceRow = {
   name: string;
   status: Exclude<DataSourceStatus, "not_configured">;
   terms_status: Exclude<DataSourceTermsStatus, "unknown">;
+  compliance_status?: Exclude<DataSourceTermsStatus, "unknown"> | null;
+  rollout_state?: "shadow" | "pilot" | "live" | "disabled" | null;
+  readiness_status?: "pass" | "warn" | "fail" | "unknown" | null;
   rate_limit_policy?: Record<string, unknown> | null;
   config_encrypted?: unknown;
   reliability_score?: number | null;
   freshness_timestamp?: string | null;
+  freshness_sla_minutes?: number | null;
+  health_status?: "ok" | "degraded" | "failed" | "unknown" | null;
+  health_detail?: string | null;
+  last_health_checked_at?: string | null;
+  last_health_latency_ms?: number | null;
   provenance?: string | null;
 };
 
@@ -116,6 +124,24 @@ function normalizeTermsStatus(value: unknown): DataSourceTermsStatus {
   if (normalized === "approved" || normalized === "restricted" || normalized === "pending_review" || normalized === "blocked") {
     return normalized;
   }
+  return "unknown";
+}
+
+function normalizeRolloutState(value: unknown): DataSourceSummary["rolloutState"] {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (normalized === "shadow" || normalized === "pilot" || normalized === "live" || normalized === "disabled") return normalized;
+  return "pilot";
+}
+
+function normalizeReadinessStatus(value: unknown): DataSourceSummary["readinessStatus"] {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (normalized === "pass" || normalized === "warn" || normalized === "fail" || normalized === "unknown") return normalized;
+  return "unknown";
+}
+
+function normalizeHealthStatus(value: unknown): DataSourceSummary["healthStatus"] {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (normalized === "ok" || normalized === "degraded" || normalized === "failed" || normalized === "unknown") return normalized;
   return "unknown";
 }
 
@@ -223,8 +249,12 @@ export function computeRuntimeMode(sourceType: string, config: Record<string, un
   return termsStatus === "approved" ? "fully-live" : "live-partial";
 }
 
-function resolveCaptureStatus(summary: Pick<DataSourceSummary, "configured" | "status" | "runtimeMode" | "termsStatus" | "complianceStatus" | "config" | "latestRunStatus">) {
+function resolveCaptureStatus(
+  summary: Pick<DataSourceSummary, "configured" | "status" | "runtimeMode" | "termsStatus" | "complianceStatus" | "config" | "latestRunStatus" | "rolloutState">
+) {
   if (!summary.configured || summary.status === "not_configured" || hasSampleRecords(summary.config)) return "simulated" as const;
+  if (summary.rolloutState === "disabled") return "blocked" as const;
+  if (summary.rolloutState === "shadow") return "live_safe_partial" as const;
   if (summary.termsStatus !== "approved" || summary.complianceStatus !== "approved") return "blocked" as const;
   if (summary.runtimeMode === "live-partial") return "live_safe_partial" as const;
   if (summary.runtimeMode === "simulated") return "simulated" as const;
@@ -237,6 +267,7 @@ function buildBuyerReadinessNote(input: {
   configured: boolean;
   status: DataSourceStatus;
   runtimeMode: DataSourceRuntimeMode;
+  rolloutState: DataSourceSummary["rolloutState"];
   termsStatus: DataSourceTermsStatus;
   complianceStatus: DataSourceTermsStatus;
   config: Record<string, unknown>;
@@ -261,6 +292,8 @@ function configuredSummaryFromCatalog(catalogKey: string): DataSourceSummary {
     configured: false,
     status: "not_configured",
     runtimeMode: computeRuntimeMode(catalog.sourceType, catalog.defaultConfig, catalog.defaultTermsStatus),
+    rolloutState: "pilot",
+    readinessStatus: "unknown",
     termsStatus: catalog.defaultTermsStatus,
     complianceStatus: catalog.defaultTermsStatus,
     freshness: 0,
@@ -274,12 +307,18 @@ function configuredSummaryFromCatalog(catalogKey: string): DataSourceSummary {
     recordsCreated: 0,
     recordsUpdated: 0,
     provenance: catalog.defaultProvenance,
+    freshnessSlaMinutes: 360,
+    healthStatus: "unknown",
+    healthDetail: null,
+    lastHealthCheckedAt: null,
+    lastHealthLatencyMs: null,
     liveRequirements: catalog.liveRequirements,
     buyerReadinessNote: buildBuyerReadinessNote({
       name: catalog.name,
       configured: false,
       status: "not_configured",
       runtimeMode: computeRuntimeMode(catalog.sourceType, catalog.defaultConfig, catalog.defaultTermsStatus),
+      rolloutState: "pilot",
       termsStatus: catalog.defaultTermsStatus,
       complianceStatus: catalog.defaultTermsStatus,
       config: catalog.defaultConfig
@@ -312,9 +351,10 @@ function buildConfiguredSummary(
   const connectorKey = catalog?.connectorKey || inferConnectorKey(row.source_type);
   const config = parseDataSourceConfig(row.config_encrypted);
   const termsStatus = normalizeTermsStatus(row.terms_status);
+  const rolloutState = normalizeRolloutState(row.rollout_state);
+  const readinessStatus = normalizeReadinessStatus(row.readiness_status);
   const connector = getConnectorByKey(connectorKey);
-  const complianceStatus =
-    connector?.compliancePolicy({
+  const policyTermsStatus = connector?.compliancePolicy({
       tenantId: "",
       sourceId: String(row.id),
       sourceType: String(row.source_type),
@@ -323,11 +363,11 @@ function buildConfiguredSummary(
         terms_status: row.terms_status,
         source_provenance: row.provenance
       }
-    }).termsStatus ||
-    normalizeTermsStatus(latestEvent?.compliance_status) ||
-    termsStatus;
+    }).termsStatus;
+  const complianceStatus = normalizeTermsStatus(row.compliance_status || policyTermsStatus || latestEvent?.compliance_status || termsStatus);
 
-  const runtimeMode = computeRuntimeMode(row.source_type, config, termsStatus);
+  const runtimeModeBase = computeRuntimeMode(row.source_type, config, termsStatus);
+  const runtimeMode: DataSourceRuntimeMode = rolloutState === "disabled" ? "simulated" : rolloutState === "shadow" ? "live-partial" : runtimeModeBase;
   const freshnessTimestamp = latestEvent?.ingested_at || row.freshness_timestamp || null;
   const recordsUpdated = Number((latestRun?.metadata as Record<string, unknown> | null)?.opportunities_updated || 0);
   const summary = {
@@ -341,6 +381,8 @@ function buildConfiguredSummary(
     configured: true,
     status: row.status,
     runtimeMode,
+    rolloutState,
+    readinessStatus,
     termsStatus,
     complianceStatus,
     freshness: freshnessScore(freshnessTimestamp),
@@ -354,12 +396,18 @@ function buildConfiguredSummary(
     recordsCreated: Number(latestRun?.records_created || 0),
     recordsUpdated,
     provenance: row.provenance || catalog?.defaultProvenance || null,
+    freshnessSlaMinutes: Math.max(30, Number(row.freshness_sla_minutes || 360)),
+    healthStatus: normalizeHealthStatus(row.health_status),
+    healthDetail: row.health_detail || null,
+    lastHealthCheckedAt: row.last_health_checked_at || null,
+    lastHealthLatencyMs: row.last_health_latency_ms != null ? Number(row.last_health_latency_ms) : null,
     liveRequirements: catalog?.liveRequirements || [],
     buyerReadinessNote: buildBuyerReadinessNote({
       name: row.name || catalog?.name || row.source_type,
       configured: true,
       status: row.status,
       runtimeMode,
+      rolloutState,
       termsStatus,
       complianceStatus,
       config
@@ -394,7 +442,9 @@ export async function listDataSourceSummaries({
 
   const { data: sourceRows, error: sourceError } = await (supabase as any)
     .from("v2_data_sources")
-    .select("id,source_type,name,status,terms_status,rate_limit_policy,config_encrypted,reliability_score,freshness_timestamp,provenance")
+    .select(
+      "id,source_type,name,status,terms_status,compliance_status,rollout_state,readiness_status,rate_limit_policy,config_encrypted,reliability_score,freshness_timestamp,freshness_sla_minutes,health_status,health_detail,last_health_checked_at,last_health_latency_ms,provenance"
+    )
     .eq("tenant_id", tenantId)
     .order("created_at", { ascending: true })
     .limit(200);
@@ -487,7 +537,12 @@ export function buildCreatePayloadFromMutation(payload: DataSourceMutationPayloa
     provenance: String(payload.provenance || catalog.defaultProvenance).trim() || null,
     rate_limit_policy: payload.rateLimitPolicy || {},
     config_encrypted: stringifyDataSourceConfig(config),
-    freshness_timestamp: null
+    freshness_timestamp: null,
+    compliance_status: payload.complianceStatus || payload.termsStatus || catalog.defaultTermsStatus,
+    rollout_state: payload.rolloutState || "pilot",
+    freshness_sla_minutes: Math.max(30, Number(payload.freshnessSlaMinutes || 360)),
+    readiness_status: "unknown",
+    readiness_reasons: []
   };
 }
 
@@ -496,6 +551,9 @@ export function buildUpdatePayloadFromMutation(payload: DataSourceMutationPayloa
   if (payload.name != null) update.name = String(payload.name).trim();
   if (payload.status != null) update.status = payload.status;
   if (payload.termsStatus != null) update.terms_status = payload.termsStatus;
+  if (payload.complianceStatus != null) update.compliance_status = payload.complianceStatus;
+  if (payload.rolloutState != null) update.rollout_state = payload.rolloutState;
+  if (payload.freshnessSlaMinutes != null) update.freshness_sla_minutes = Math.max(30, Math.round(Number(payload.freshnessSlaMinutes) || 360));
   if (payload.reliabilityScore != null) update.reliability_score = clampScore(payload.reliabilityScore);
   if (payload.provenance != null) update.provenance = String(payload.provenance).trim() || null;
   if (payload.rateLimitPolicy != null) update.rate_limit_policy = payload.rateLimitPolicy;

--- a/src/lib/control-plane/readiness.ts
+++ b/src/lib/control-plane/readiness.ts
@@ -47,6 +47,14 @@ function usesSampleRecords(source: DataSourceSummary) {
   return Array.isArray(source.config.sample_records) && source.config.sample_records.length > 0;
 }
 
+function isStaleForSla(source: DataSourceSummary) {
+  if (!source.freshnessTimestamp) return true;
+  const timestamp = new Date(source.freshnessTimestamp).getTime();
+  if (!Number.isFinite(timestamp)) return true;
+  const ageMinutes = Math.max(0, Math.round((Date.now() - timestamp) / 60000));
+  return ageMinutes > Math.max(30, Number(source.freshnessSlaMinutes || 360));
+}
+
 export function buildEnvironmentReadinessState(reason: string, detail?: string): ReadinessState {
   return {
     mode: "blocked",
@@ -66,6 +74,24 @@ export function buildDataSourceReadinessState(source: DataSourceSummary): Readin
       issue("not_configured", `${source.name} is not configured yet.`, "Add the source to this tenant and save the required config before using it.")
     );
     recommendedActions.push("Add the source to the tenant control plane.");
+  }
+
+  if (source.rolloutState === "disabled") {
+    blockingIssues.push(
+      issue("rollout_blocked", `${source.name} is disabled by rollout policy.`, "Set rollout_state to pilot or live to allow buyer-proof capture.")
+    );
+    recommendedActions.push("Set rollout_state to pilot or live.");
+  }
+
+  if (source.rolloutState === "shadow") {
+    blockingIssues.push(
+      issue(
+        "rollout_blocked",
+        `${source.name} is in shadow rollout mode.`,
+        "Shadow mode is visible to operators, but blocked from buyer-proof capture until promoted."
+      )
+    );
+    recommendedActions.push("Promote rollout_state from shadow to pilot/live when source quality is verified.");
   }
 
   if (termsBlocked(source.termsStatus) || termsBlocked(source.complianceStatus)) {
@@ -121,6 +147,17 @@ export function buildDataSourceReadinessState(source: DataSourceSummary): Readin
     recommendedActions.push("Clear the remaining live gating issue before using this source in buyer-proof flows.");
   }
 
+  if ((source.sourceType === "incident" || source.sourceType === "weather") && isStaleForSla(source)) {
+    blockingIssues.push(
+      issue(
+        "stale_data",
+        `${source.name} data is stale for its freshness SLA.`,
+        `freshness_timestamp=${source.freshnessTimestamp || "none"} exceeds freshness_sla_minutes=${source.freshnessSlaMinutes}.`
+      )
+    );
+    recommendedActions.push("Run source healthcheck and connector run to refresh Tier-1 data before buyer-proof usage.");
+  }
+
   return {
     mode: blockingIssues.length > 0 ? "blocked" : "live",
     live: blockingIssues.length === 0,
@@ -131,7 +168,7 @@ export function buildDataSourceReadinessState(source: DataSourceSummary): Readin
 }
 
 export function buyerReadinessNoteForSource(
-  source: Pick<DataSourceSummary, "name" | "configured" | "status" | "runtimeMode" | "termsStatus" | "complianceStatus"> & {
+  source: Pick<DataSourceSummary, "name" | "configured" | "status" | "runtimeMode" | "rolloutState" | "termsStatus" | "complianceStatus"> & {
     config?: Record<string, unknown>;
   }
 ) {
@@ -144,6 +181,12 @@ export function buyerReadinessNoteForSource(
   }
   if (termsBlocked(source.termsStatus) || termsBlocked(source.complianceStatus)) {
     return `Blocked for live proof until ${source.termsStatus.replace(/_/g, " ")} terms/compliance are cleared.`;
+  }
+  if (source.rolloutState === "disabled") {
+    return "Disabled by rollout policy. Not eligible for live capture.";
+  }
+  if (source.rolloutState === "shadow") {
+    return "Shadow rollout only. Visible to operators, excluded from buyer-proof capture.";
   }
   if (source.runtimeMode === "simulated") {
     return "Visible to operators, but still simulated and excluded from buyer-proof metrics.";

--- a/src/lib/control-plane/types.ts
+++ b/src/lib/control-plane/types.ts
@@ -12,7 +12,9 @@ export type ReadinessIssueCode =
   | "simulated"
   | "live_partial"
   | "blocked_by_terms"
-  | "not_live_in_environment";
+  | "not_live_in_environment"
+  | "stale_data"
+  | "rollout_blocked";
 
 export type ReadinessIssue = {
   code: ReadinessIssueCode;
@@ -48,6 +50,8 @@ export type DataSourceSummary = {
   configured: boolean;
   status: DataSourceStatus;
   runtimeMode: DataSourceRuntimeMode;
+  rolloutState: "shadow" | "pilot" | "live" | "disabled";
+  readinessStatus: "pass" | "warn" | "fail" | "unknown";
   termsStatus: DataSourceTermsStatus;
   complianceStatus: DataSourceTermsStatus;
   freshness: number;
@@ -61,6 +65,11 @@ export type DataSourceSummary = {
   recordsCreated: number;
   recordsUpdated: number;
   provenance: string | null;
+  freshnessSlaMinutes: number;
+  healthStatus: "ok" | "degraded" | "failed" | "unknown";
+  healthDetail: string | null;
+  lastHealthCheckedAt: string | null;
+  lastHealthLatencyMs: number | null;
   liveRequirements: string[];
   buyerReadinessNote: string;
   captureStatus: DataSourceCaptureStatus;
@@ -75,6 +84,9 @@ export type DataSourceMutationPayload = {
   name?: string;
   status?: Exclude<DataSourceStatus, "not_configured">;
   termsStatus?: Exclude<DataSourceTermsStatus, "unknown">;
+  complianceStatus?: Exclude<DataSourceTermsStatus, "unknown">;
+  rolloutState?: "shadow" | "pilot" | "live" | "disabled";
+  freshnessSlaMinutes?: number;
   reliabilityScore?: number;
   provenance?: string;
   config?: Record<string, unknown>;

--- a/src/lib/v2/connectors/incidents/index.ts
+++ b/src/lib/v2/connectors/incidents/index.ts
@@ -74,6 +74,19 @@ function hasConfiguredIncidentFeed(input: ConnectorPullInput) {
   return Boolean(String(input.config.feed_url || input.config.endpoint || "").trim());
 }
 
+function freshnessSlaHours(input: ConnectorPullInput) {
+  const configured = Number(input.config.max_event_age_hours ?? input.config.freshness_sla_hours ?? 48);
+  if (!Number.isFinite(configured)) return 48;
+  return Math.max(1, Math.min(168, Math.round(configured)));
+}
+
+function parseOccurredAt(raw: unknown) {
+  const text = String(raw || "").trim();
+  if (!text) return null;
+  const parsed = new Date(text);
+  return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : null;
+}
+
 async function pullIncidentPages(input: ConnectorPullInput) {
   const pages = await scrapeConfiguredPagesWithFirecrawl({
     config: input.config,
@@ -112,6 +125,9 @@ export const incidentConnector: ConnectorAdapter = {
     const scrapedPages = await pullIncidentPages(input);
     if (scrapedPages.length > 0) return scrapedPages;
 
+    const liveConfigured = hasConfiguredIncidentPages(input) || hasConfiguredIncidentFeed(input);
+    if (liveConfigured) return [];
+
     const sample = input.config.sample_records;
     if (Array.isArray(sample)) {
       return sample.filter((row): row is Record<string, unknown> => Boolean(row && typeof row === "object"));
@@ -123,15 +139,24 @@ export const incidentConnector: ConnectorAdapter = {
     const defaultSourceName = String(input.config.connector_name || input.config.source_name || "Generic Incident Feed");
     const defaultSourceProvenance = String(input.config.source_provenance || "public.incident.feed");
 
-    return records.map((record, index): ConnectorNormalizedEvent => {
+    const maxAgeHours = freshnessSlaHours(input);
+    const cutoffMs = Date.now() - maxAgeHours * 60 * 60 * 1000;
+
+    return records
+      .map((record, index): ConnectorNormalizedEvent | null => {
       const category = classifyIncidentCategory(record);
       const lines = serviceLineCandidates(category);
       const urgency = toNumber(record.urgency_hint, category.includes("emergency") ? 84 : 70);
       const severity = toNumber(record.severity, category.includes("fire") ? 82 : 68);
       const title = String(record.title || record.incident_type || `Incident ${index + 1}`);
-      const occurredAt = String(record.occurred_at || record.created_at || new Date().toISOString());
+      const sourceOccurredAt = parseOccurredAt(record.occurred_at || record.created_at);
+      const occurredAt = sourceOccurredAt || new Date().toISOString();
+      const timestampConfidence = sourceOccurredAt ? "source" : "inferred";
       const sourceName = String(record.provider || record.source_name || defaultSourceName);
       const sourceProvenance = String(record.source_provenance || defaultSourceProvenance);
+      const occurredAtMs = new Date(occurredAt).getTime();
+      if (!Number.isFinite(occurredAtMs)) return null;
+      if (occurredAtMs < cutoffMs) return null;
 
       return {
         occurredAt,
@@ -163,10 +188,14 @@ export const incidentConnector: ConnectorAdapter = {
         normalizedPayload: {
           incident_category: category,
           source_provenance: sourceProvenance,
+          timestamp_confidence: timestampConfidence,
+          timestamp_reason: sourceOccurredAt ? "source_event_timestamp" : "missing_source_timestamp",
+          data_freshness_score: sourceOccurredAt ? undefined : 0,
           connector_version: CONNECTOR_VERSION
         }
       };
-    });
+    })
+      .filter((event): event is ConnectorNormalizedEvent => Boolean(event));
   },
 
   dedupeKey(event) {
@@ -228,7 +257,7 @@ export const incidentConnector: ConnectorAdapter = {
     if (hasConfiguredIncidentFeed(input)) {
       return {
         ok: true,
-        detail: "Incident feed endpoint configured"
+        detail: "Incident feed endpoint configured (live-mode, no sample fallback)"
       };
     }
 

--- a/src/lib/v2/data-sources.ts
+++ b/src/lib/v2/data-sources.ts
@@ -14,6 +14,8 @@ export type DataSourceMutationPayload = {
   active?: boolean;
   termsStatus?: string;
   complianceStatus?: string;
+  rolloutState?: "shadow" | "pilot" | "live" | "disabled";
+  freshnessSlaMinutes?: number;
   provenance?: string;
   reliabilityScore?: number;
   freshnessTimestamp?: string | null;
@@ -33,6 +35,8 @@ export type DataSourceSummary = {
   status: string;
   termsStatus: string;
   complianceStatus: string;
+  rolloutState: "shadow" | "pilot" | "live" | "disabled";
+  readinessStatus: "pass" | "warn" | "fail" | "unknown";
   runtimeMode: DataSourceRuntimeMode;
   provenance: string;
   reliabilityScore: number;
@@ -48,6 +52,11 @@ export type DataSourceSummary = {
   latestEventComplianceStatus: string | null;
   latestEventFreshnessScore: number | null;
   latestEventReliabilityScore: number | null;
+  freshnessSlaMinutes: number;
+  healthStatus: "ok" | "degraded" | "failed" | "unknown";
+  healthDetail: string | null;
+  lastHealthCheckedAt: string | null;
+  lastHealthLatencyMs: number | null;
   complianceFlags: Record<string, unknown>;
   rateLimitPolicy: Record<string, unknown>;
   configPreview: Record<string, unknown>;
@@ -187,6 +196,24 @@ function normalizeStatus(value: unknown) {
   return raw || "paused";
 }
 
+function normalizeRolloutState(value: unknown): DataSourceSummary["rolloutState"] {
+  const normalized = asText(value).toLowerCase();
+  if (normalized === "shadow" || normalized === "pilot" || normalized === "live" || normalized === "disabled") return normalized;
+  return "pilot";
+}
+
+function normalizeReadinessStatus(value: unknown): DataSourceSummary["readinessStatus"] {
+  const normalized = asText(value).toLowerCase();
+  if (normalized === "pass" || normalized === "warn" || normalized === "fail" || normalized === "unknown") return normalized;
+  return "unknown";
+}
+
+function normalizeHealthStatus(value: unknown): DataSourceSummary["healthStatus"] {
+  const normalized = asText(value).toLowerCase();
+  if (normalized === "ok" || normalized === "degraded" || normalized === "failed" || normalized === "unknown") return normalized;
+  return "unknown";
+}
+
 function latestBySource<T extends Record<string, unknown>>(rows: T[], sourceKey = "source_id") {
   const latest = new Map<string, T>();
   for (const row of rows) {
@@ -255,7 +282,10 @@ function deriveRuntimeMode({
   latestRun?: Record<string, unknown> | null;
   policyAllowed: boolean;
 }): DataSourceRuntimeMode {
+  const rolloutState = normalizeRolloutState(sourceRow.rollout_state);
   if (normalizeStatus(sourceRow.status) !== "active") return "simulated";
+  if (rolloutState === "disabled") return "simulated";
+  if (rolloutState === "shadow") return "live-partial";
   if (!policyAllowed) return "live-partial";
 
   const termsStatus = asText(sourceRow.terms_status || sourceRow.compliance_status).toLowerCase();
@@ -313,10 +343,10 @@ export async function getDataSourceSummaries({
     { data: eventRows, error: eventError }
   ] = await Promise.all([
     supabase
-      .from("v2_data_sources")
-      .select(
-        "id,source_type,name,status,terms_status,provenance,reliability_score,freshness_timestamp,rate_limit_policy,compliance_flags,config_encrypted,compliance_status,created_at,updated_at"
-      )
+    .from("v2_data_sources")
+    .select(
+      "id,source_type,name,status,terms_status,provenance,reliability_score,freshness_timestamp,freshness_sla_minutes,rate_limit_policy,compliance_flags,config_encrypted,compliance_status,rollout_state,readiness_status,health_status,health_detail,last_health_checked_at,last_health_latency_ms,created_at,updated_at"
+    )
       .eq("tenant_id", tenantId)
       .order("created_at", { ascending: false }),
     supabase
@@ -354,7 +384,7 @@ export async function getDataSourceSummaries({
     const latestRun = latestRuns.get(sourceId) || null;
     const latestEvent = latestEvents.get(sourceId) || null;
     const termsStatus = asText(latestEvent?.compliance_status || sourceRow.terms_status || compliancePolicy?.termsStatus || "pending_review");
-    const complianceStatus = asText(latestEvent?.compliance_status || sourceRow.compliance_status || termsStatus || compliancePolicy?.termsStatus || "pending_review");
+    const complianceStatus = asText(sourceRow.compliance_status || termsStatus || compliancePolicy?.termsStatus || "pending_review");
     const runtimeMode = deriveRuntimeMode({
       sourceRow: {
         ...sourceRow,
@@ -376,6 +406,8 @@ export async function getDataSourceSummaries({
       status: normalizeStatus(sourceRow.status),
       termsStatus,
       complianceStatus,
+      rolloutState: normalizeRolloutState(sourceRow.rollout_state),
+      readinessStatus: normalizeReadinessStatus(sourceRow.readiness_status),
       runtimeMode,
       provenance: asText(sourceRow.provenance),
       reliabilityScore: asNumber(sourceRow.reliability_score, 0),
@@ -391,6 +423,11 @@ export async function getDataSourceSummaries({
       latestEventComplianceStatus: asText(latestEvent?.compliance_status) || null,
       latestEventFreshnessScore: latestEvent ? asNumber(latestEvent.data_freshness_score, 0) : null,
       latestEventReliabilityScore: latestEvent ? asNumber(latestEvent.source_reliability_score, 0) : null,
+      freshnessSlaMinutes: Math.max(30, asNumber(sourceRow.freshness_sla_minutes, 360)),
+      healthStatus: normalizeHealthStatus(sourceRow.health_status),
+      healthDetail: asText(sourceRow.health_detail) || null,
+      lastHealthCheckedAt: asText(sourceRow.last_health_checked_at) || null,
+      lastHealthLatencyMs: sourceRow.last_health_latency_ms != null ? asNumber(sourceRow.last_health_latency_ms, 0) : null,
       complianceFlags: parseRecord(sourceRow.compliance_flags),
       rateLimitPolicy: parseRecord(sourceRow.rate_limit_policy),
       configPreview: buildSourceConfigPreview(sourceRow)
@@ -425,7 +462,7 @@ export async function fetchDataSourceRow({
   const { data, error } = await supabase
     .from("v2_data_sources")
     .select(
-      "id,tenant_id,source_type,name,status,terms_status,provenance,reliability_score,freshness_timestamp,rate_limit_policy,compliance_flags,config_encrypted,compliance_status,created_at,updated_at"
+      "id,tenant_id,source_type,name,status,terms_status,provenance,reliability_score,freshness_timestamp,freshness_sla_minutes,rate_limit_policy,compliance_flags,config_encrypted,compliance_status,rollout_state,readiness_status,health_status,health_detail,last_health_checked_at,last_health_latency_ms,created_at,updated_at"
     )
     .eq("tenant_id", tenantId)
     .eq("id", sourceId)
@@ -450,7 +487,7 @@ function buildStoredConfigValue(
     merged.connector_key = connectorKey;
   }
 
-  return merged;
+  return JSON.stringify(merged);
 }
 
 export function buildDataSourceInsertPayload({
@@ -479,9 +516,13 @@ export function buildDataSourceInsertPayload({
     provenance: asText(body.provenance) || null,
     reliability_score: asNumber(body.reliabilityScore, 0),
     freshness_timestamp: body.freshnessTimestamp || new Date().toISOString(),
+    freshness_sla_minutes: Math.max(30, asNumber(body.freshnessSlaMinutes, 360)),
     rate_limit_policy: body.rateLimitPolicy || {},
     compliance_flags: body.complianceFlags || {},
     compliance_status: asText(body.complianceStatus) || termsStatus,
+    rollout_state: body.rolloutState || "pilot",
+    readiness_status: "unknown",
+    readiness_reasons: [],
     config_encrypted: buildStoredConfigValue(body.config, connectorKey, {})
   };
 }
@@ -499,6 +540,8 @@ export function buildDataSourceUpdatePayload(
   }
   if (body.termsStatus != null) payload.terms_status = asText(body.termsStatus) || "pending_review";
   if (body.complianceStatus != null) payload.compliance_status = asText(body.complianceStatus) || null;
+  if (body.rolloutState != null) payload.rollout_state = normalizeRolloutState(body.rolloutState);
+  if (body.freshnessSlaMinutes != null) payload.freshness_sla_minutes = Math.max(30, asNumber(body.freshnessSlaMinutes, 360));
   if (body.provenance != null) payload.provenance = asText(body.provenance) || null;
   if (body.reliabilityScore != null) payload.reliability_score = asNumber(body.reliabilityScore, 0);
   if (body.freshnessTimestamp !== undefined) payload.freshness_timestamp = body.freshnessTimestamp || null;
@@ -580,6 +623,16 @@ export async function runDataSourceConnector({
   });
 
   if (!health.ok) {
+    await supabase
+      .from("v2_data_sources")
+      .update({
+        health_status: "failed",
+        health_detail: asText(health.detail) || "Connector healthcheck failed",
+        last_health_checked_at: new Date().toISOString(),
+        last_health_latency_ms: Number.isFinite(health.latencyMs) ? Number(health.latencyMs) : null
+      })
+      .eq("tenant_id", tenantId)
+      .eq("id", sourceId);
     return {
       sourceSummary: sourceSummaryBeforeRun,
       health: summarizedHealth,
@@ -609,6 +662,17 @@ export async function runDataSourceConnector({
   });
 
   const sourceSummary = await getDataSourceSummary({ supabase, tenantId, sourceId });
+  await supabase
+    .from("v2_data_sources")
+    .update({
+      health_status: run.status === "failed" ? "failed" : run.status === "partial" || run.status === "stale" ? "degraded" : "ok",
+      health_detail: run.errorSummary || (run.status === "replayed" ? "Replay run completed" : "Connector run completed"),
+      last_health_checked_at: new Date().toISOString(),
+      freshness_timestamp: sourceSummary.latestEventAt || sourceSummary.freshnessTimestamp,
+      last_health_latency_ms: Number.isFinite(health.latencyMs) ? Number(health.latencyMs) : null
+    })
+    .eq("tenant_id", tenantId)
+    .eq("id", sourceId);
   return {
     sourceSummary,
     health: summarizeConnectorHealth({ sourceSummary, health, connectorKey }),
@@ -634,6 +698,16 @@ export async function probeDataSourceHealth({
   if (!connector) throw new Error(`Connector not found for key ${connectorKey}`);
 
   const health = await connector.healthcheck(connectorConfig.input);
+  await supabase
+    .from("v2_data_sources")
+    .update({
+      health_status: health.ok ? "ok" : "failed",
+      health_detail: asText(health.detail) || (health.ok ? "Connector reachable" : "Connector healthcheck failed"),
+      last_health_checked_at: new Date().toISOString(),
+      last_health_latency_ms: Number.isFinite(health.latencyMs) ? Number(health.latencyMs) : null
+    })
+    .eq("tenant_id", tenantId)
+    .eq("id", sourceId);
   const sourceSummary = await getDataSourceSummary({ supabase, tenantId, sourceId });
 
   return {

--- a/src/lib/v2/readiness.ts
+++ b/src/lib/v2/readiness.ts
@@ -12,6 +12,7 @@ export type ProductionReadinessTenantSummary = {
   serviceAreaConfigured: boolean;
   activeDataSources: number;
   liveSafeDataSources: number;
+  tier1FreshSources: number;
 };
 
 export type ProductionReadinessSummary = {
@@ -354,6 +355,7 @@ async function resolveTenantSummary(
   const activeTerritories = await countActiveRows(supabase, "v2_territories", tenantId);
   const activeDataSources = await countActiveRows(supabase, "v2_data_sources", tenantId, "status", "active");
   const liveSafeDataSources = await countLiveSafeSources(supabase, tenantId);
+  const tier1FreshSources = await countTier1FreshSources(supabase, tenantId);
   const serviceAreaConfigured = await hasConfiguredServiceArea(supabase, tenantId);
 
   return {
@@ -362,7 +364,8 @@ async function resolveTenantSummary(
     activeTerritories,
     serviceAreaConfigured,
     activeDataSources,
-    liveSafeDataSources
+    liveSafeDataSources,
+    tier1FreshSources
   };
 }
 
@@ -411,6 +414,26 @@ async function countLiveSafeSources(supabase: SupabaseClient, tenantId: string) 
   }
 }
 
+async function countTier1FreshSources(supabase: SupabaseClient, tenantId: string) {
+  try {
+    const sources = await getDataSourceSummaries({ supabase, tenantId });
+    const now = Date.now();
+    return sources.filter((source) => {
+      if (source.status !== "active") return false;
+      if (source.runtimeMode === "simulated") return false;
+      if (!["incident", "weather"].includes(String(source.sourceType || "").toLowerCase())) return false;
+      const ts = source.latestEventAt || source.freshnessTimestamp;
+      if (!ts) return false;
+      const parsed = new Date(ts).getTime();
+      if (!Number.isFinite(parsed)) return false;
+      const slaMinutes = Math.max(30, Number(source.freshnessSlaMinutes || 360));
+      return now - parsed <= slaMinutes * 60 * 1000;
+    }).length;
+  } catch {
+    return 0;
+  }
+}
+
 async function checkTenantReadiness(tenant: ProductionReadinessTenantSummary | null): Promise<ProductionReadinessCheck[]> {
   if (!tenant) {
     return [
@@ -418,7 +441,8 @@ async function checkTenantReadiness(tenant: ProductionReadinessTenantSummary | n
       warn("active_territories", false, "No tenant context available for territory validation."),
       warn("service_area", false, "No tenant context available for service area validation."),
       warn("active_data_sources", false, "No tenant context available for data source validation."),
-      warn("live_safe_sources", false, "No tenant context available for live-safe source validation.")
+      warn("live_safe_sources", false, "No tenant context available for live-safe source validation."),
+      warn("tier1_freshness", false, "No tenant context available for Tier-1 freshness validation.")
     ];
   }
 
@@ -448,6 +472,12 @@ async function checkTenantReadiness(tenant: ProductionReadinessTenantSummary | n
     checks.push(pass("live_safe_sources", true, `Live-safe data sources: ${tenant.liveSafeDataSources}.`, String(tenant.liveSafeDataSources)));
   } else {
     checks.push(fail("live_safe_sources", true, "No live-safe data sources are active.", String(tenant.liveSafeDataSources)));
+  }
+
+  if (tenant.tier1FreshSources > 0) {
+    checks.push(pass("tier1_freshness", true, `Fresh Tier-1 sources (incident/weather): ${tenant.tier1FreshSources}.`, String(tenant.tier1FreshSources)));
+  } else {
+    checks.push(fail("tier1_freshness", true, "No fresh Tier-1 incident/weather sources within freshness SLA.", String(tenant.tier1FreshSources)));
   }
 
   return checks;

--- a/supabase/migrations/20260406100000_source_registry_rollout_and_tier1_controls.sql
+++ b/supabase/migrations/20260406100000_source_registry_rollout_and_tier1_controls.sql
@@ -1,0 +1,64 @@
+-- Source registry activation and Tier-1 controls:
+-- - Persist rollout/readiness/health state on v2_data_sources
+-- - Align compliance_status with source-level policy state
+-- - Add freshness SLA controls for source-specific readiness checks
+
+alter table public.v2_data_sources
+  add column if not exists compliance_status public.v2_terms_status not null default 'pending_review',
+  add column if not exists rollout_state text not null default 'pilot',
+  add column if not exists readiness_status text not null default 'unknown',
+  add column if not exists readiness_checked_at timestamptz,
+  add column if not exists readiness_reasons jsonb not null default '[]'::jsonb,
+  add column if not exists freshness_sla_minutes integer not null default 360,
+  add column if not exists health_status text not null default 'unknown',
+  add column if not exists health_detail text,
+  add column if not exists last_health_checked_at timestamptz,
+  add column if not exists last_health_latency_ms integer;
+
+update public.v2_data_sources
+set
+  compliance_status = coalesce(compliance_status, terms_status),
+  rollout_state = case
+    when lower(coalesce(rollout_state, '')) in ('shadow', 'pilot', 'live', 'disabled') then lower(rollout_state)
+    else 'pilot'
+  end,
+  readiness_status = case
+    when lower(coalesce(readiness_status, '')) in ('pass', 'warn', 'fail', 'unknown') then lower(readiness_status)
+    else 'unknown'
+  end,
+  freshness_sla_minutes = greatest(30, coalesce(freshness_sla_minutes, 360)),
+  health_status = case
+    when lower(coalesce(health_status, '')) in ('ok', 'degraded', 'failed', 'unknown') then lower(health_status)
+    else 'unknown'
+  end
+where true;
+
+do $$
+begin
+  if not exists (select 1 from pg_constraint where conname = 'v2_data_sources_rollout_state_check') then
+    alter table public.v2_data_sources
+      add constraint v2_data_sources_rollout_state_check
+      check (rollout_state in ('shadow', 'pilot', 'live', 'disabled'));
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'v2_data_sources_readiness_status_check') then
+    alter table public.v2_data_sources
+      add constraint v2_data_sources_readiness_status_check
+      check (readiness_status in ('pass', 'warn', 'fail', 'unknown'));
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'v2_data_sources_health_status_check') then
+    alter table public.v2_data_sources
+      add constraint v2_data_sources_health_status_check
+      check (health_status in ('ok', 'degraded', 'failed', 'unknown'));
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'v2_data_sources_freshness_sla_minutes_check') then
+    alter table public.v2_data_sources
+      add constraint v2_data_sources_freshness_sla_minutes_check
+      check (freshness_sla_minutes >= 30 and freshness_sla_minutes <= 10080);
+  end if;
+end $$;
+
+create index if not exists v2_data_sources_tenant_rollout_idx
+  on public.v2_data_sources (tenant_id, rollout_state, status);
+
+create index if not exists v2_data_sources_tenant_compliance_idx
+  on public.v2_data_sources (tenant_id, compliance_status, status);

--- a/tests/buyer-readiness.spec.ts
+++ b/tests/buyer-readiness.spec.ts
@@ -13,6 +13,8 @@ test("data-source readiness blocks simulated and terms-gated sources", () => {
     configured: true,
     status: "active",
     runtimeMode: "simulated",
+    rolloutState: "pilot",
+    readinessStatus: "unknown",
     termsStatus: "pending_review",
     complianceStatus: "pending_review",
     freshness: 0,
@@ -26,6 +28,11 @@ test("data-source readiness blocks simulated and terms-gated sources", () => {
     recordsCreated: 0,
     recordsUpdated: 0,
     provenance: "permits.provider",
+    freshnessSlaMinutes: 360,
+    healthStatus: "unknown",
+    healthDetail: null,
+    lastHealthCheckedAt: null,
+    lastHealthLatencyMs: null,
     liveRequirements: ["Provider URL"],
     buyerReadinessNote: "",
     captureStatus: "simulated",
@@ -47,6 +54,7 @@ test("buyer readiness note tells the truth about live-safe sources", () => {
       configured: true,
       status: "active",
       runtimeMode: "fully-live",
+      rolloutState: "live",
       termsStatus: "approved",
       complianceStatus: "approved"
     })

--- a/tests/control-plane-readiness.spec.ts
+++ b/tests/control-plane-readiness.spec.ts
@@ -15,6 +15,8 @@ function makeSource(overrides: Partial<DataSourceSummary> = {}): DataSourceSumma
     configured: true,
     status: "active",
     runtimeMode: "fully-live",
+    rolloutState: "live",
+    readinessStatus: "pass",
     termsStatus: "approved",
     complianceStatus: "approved",
     freshness: 92,
@@ -28,6 +30,11 @@ function makeSource(overrides: Partial<DataSourceSummary> = {}): DataSourceSumma
     recordsCreated: 4,
     recordsUpdated: 2,
     provenance: "api.weather.gov",
+    freshnessSlaMinutes: 360,
+    healthStatus: "ok",
+    healthDetail: "Connector healthy",
+    lastHealthCheckedAt: new Date().toISOString(),
+    lastHealthLatencyMs: 120,
     liveRequirements: [],
     buyerReadinessNote: "Live-safe and eligible for buyer-proof reporting.",
     captureStatus: "capturing_live",
@@ -129,6 +136,7 @@ test("sample-backed sources are excluded from operator and buyer truth paths", (
     configured: source.configured,
     status: source.status,
     runtimeMode: source.runtimeMode,
+    rolloutState: source.rolloutState,
     termsStatus: source.termsStatus,
     complianceStatus: source.complianceStatus,
     config: source.config
@@ -138,4 +146,40 @@ test("sample-backed sources are excluded from operator and buyer truth paths", (
   expect(readiness.blockingIssues.map((issue) => issue.code)).toContain("simulated");
   expect(readiness.recommendedActions).toContain("Remove sample_records before using this source for live capture or buyer-proof reporting.");
   expect(buyerNote).toContain("excluded from live capture and buyer-proof metrics");
+});
+
+test("stale Tier-1 sources block readiness with explicit stale_data issue", () => {
+  const staleTimestamp = new Date(Date.now() - 8 * 60 * 60 * 1000).toISOString();
+  const readiness = buildDataSourceReadinessState(
+    makeSource({
+      sourceType: "incident",
+      name: "Incident Feed",
+      freshnessTimestamp: staleTimestamp,
+      freshnessSlaMinutes: 180
+    })
+  );
+
+  expect(readiness.mode).toBe("blocked");
+  expect(readiness.blockingIssues.map((issue) => issue.code)).toContain("stale_data");
+});
+
+test("shadow rollout mode blocks buyer-proof readiness until promoted", () => {
+  const source = makeSource({
+    rolloutState: "shadow"
+  });
+  const readiness = buildDataSourceReadinessState(source);
+  const buyerNote = buyerReadinessNoteForSource({
+    name: source.name,
+    configured: source.configured,
+    status: source.status,
+    runtimeMode: source.runtimeMode,
+    rolloutState: source.rolloutState,
+    termsStatus: source.termsStatus,
+    complianceStatus: source.complianceStatus,
+    config: source.config
+  });
+
+  expect(readiness.mode).toBe("blocked");
+  expect(readiness.blockingIssues.map((issue) => issue.code)).toContain("rollout_blocked");
+  expect(buyerNote).toContain("Shadow rollout only");
 });

--- a/tests/v2-firecrawl-incident-operator-flow.spec.ts
+++ b/tests/v2-firecrawl-incident-operator-flow.spec.ts
@@ -29,7 +29,7 @@ test("Firecrawl-backed incident source creates an operator-facing opportunity", 
               title: "County flood response bulletin",
               description: "Basement flooding and emergency response activity",
               sourceURL: "https://county.example.gov/incidents/flood-response",
-              publishedTime: "2026-03-16T10:00:00.000Z"
+              publishedTime: new Date().toISOString()
             }
           }
         }),
@@ -213,6 +213,7 @@ test("Firecrawl-backed incident source creates an operator-facing opportunity", 
         source_name: "County Incidents",
         terms_status: "approved",
         use_firecrawl: true,
+        max_event_age_hours: 9999,
         firecrawl_api_key: "fc-test-key",
         page_urls: ["https://county.example.gov/incidents/flood-response"],
         location_text: "Buffalo, NY"
@@ -228,6 +229,14 @@ test("Firecrawl-backed incident source creates an operator-facing opportunity", 
     expect(opportunities[0]?.title).toBe("County flood response bulletin");
     expect(opportunities[0]?.opportunity_type).toBe("flood_incident");
     expect(opportunities[0]?.service_line).toBe("restoration");
+    expect(opportunities[0]?.contact_status).toBe("identified");
+    expect(opportunities[0]?.routing_status).toBe("pending");
+    expect(opportunities[0]?.lifecycle_status).toBe("new");
+    const explainability = (opportunities[0]?.explainability_json as Record<string, unknown>) || {};
+    expect(typeof explainability.confidence_score).toBe("number");
+    expect(typeof explainability.signal_count).toBe("number");
+    expect(Array.isArray(explainability.source_types)).toBeTruthy();
+    expect(typeof explainability.event_category).toBe("string");
     expect(String((sourceEvents[0]?.normalized_payload as Record<string, unknown>)?.source_provenance || "")).toBe(
       "https://county.example.gov/incidents/flood-response"
     );

--- a/tests/v2-incidents-hardening.spec.ts
+++ b/tests/v2-incidents-hardening.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+import { incidentConnector } from "../src/lib/v2/connectors/incidents";
+
+test("incident connector avoids sample fallback when live source is configured", async () => {
+  const records = await incidentConnector.pull({
+    tenantId: "tenant-1",
+    sourceId: "source-1",
+    sourceType: "incident",
+    config: {
+      feed_url: "https://county.example.gov/incidents.json",
+      sample_records: [{ id: "sample-1", title: "sample" }]
+    }
+  });
+
+  expect(records).toEqual([]);
+});
+
+test("incident connector stale-vs-fresh filtering and timestamp confidence", async () => {
+  const now = Date.now();
+  const stale = new Date(now - 80 * 60 * 60 * 1000).toISOString();
+  const fresh = new Date(now - 20 * 60 * 1000).toISOString();
+
+  const events = await incidentConnector.normalize(
+    [
+      { id: "stale-1", title: "Old water incident", occurred_at: stale, event_type: "water incident" },
+      { id: "fresh-1", title: "Fresh water incident", occurred_at: fresh, event_type: "water incident" },
+      { id: "missing-ts", title: "Emergency response no timestamp", event_type: "emergency response" }
+    ],
+    {
+      tenantId: "tenant-1",
+      sourceId: "source-1",
+      sourceType: "incident",
+      config: {
+        max_event_age_hours: 48
+      }
+    }
+  );
+
+  expect(events.map((entry) => entry.rawPayload?.id)).toEqual(["fresh-1", "missing-ts"]);
+  const freshEvent = events.find((entry) => String(entry.rawPayload?.id) === "fresh-1");
+  const inferredEvent = events.find((entry) => String(entry.rawPayload?.id) === "missing-ts");
+  expect((freshEvent?.normalizedPayload as Record<string, unknown>)?.timestamp_confidence).toBe("source");
+  expect((inferredEvent?.normalizedPayload as Record<string, unknown>)?.timestamp_confidence).toBe("inferred");
+  expect((inferredEvent?.normalizedPayload as Record<string, unknown>)?.data_freshness_score).toBe(0);
+});
+
+test("incident connector emits stable dedupe keys for duplicate records", async () => {
+  const occurredAt = new Date().toISOString();
+  const events = await incidentConnector.normalize(
+    [
+      { id: "dup-1", title: "Main break", occurred_at: occurredAt, provider: "County Feed" },
+      { id: "dup-1", title: "Main break", occurred_at: occurredAt, provider: "County Feed" }
+    ],
+    {
+      tenantId: "tenant-1",
+      sourceId: "source-1",
+      sourceType: "incident",
+      config: {}
+    }
+  );
+
+  expect(events).toHaveLength(2);
+  expect(events[0]?.dedupeKey).toBe(events[1]?.dedupeKey);
+});
+
+test("incident healthcheck fails safely when firecrawl scraping is configured without key", async () => {
+  const health = await incidentConnector.healthcheck({
+    tenantId: "tenant-1",
+    sourceId: "source-1",
+    sourceType: "incident",
+    config: {
+      use_firecrawl: true,
+      page_urls: ["https://county.example.gov/incidents/flood-response"]
+    }
+  });
+
+  expect(health.ok).toBeFalsy();
+  expect(String(health.detail || "")).toContain("FIRECRAWL_API_KEY");
+});


### PR DESCRIPTION
## What Changed
- activated source registry as runtime-backed state on `v2_data_sources` by adding persisted rollout/readiness/health/freshness-SLA fields
- hardened the Tier-1 incident source path only (`incidents.generic`):
  - removed silent sample fallback when live source config exists
  - added stale-vs-fresh filtering with configurable max event age
  - added timestamp confidence metadata so inferred timestamps cannot masquerade as high-confidence source freshness
- wired source health/readiness persistence updates during health probes and source runs
- added Tier-1 freshness gating to readiness checks (incident/weather freshness SLA)
- updated direct connector-run endpoint to honor rollout-state safety (`shadow`/`disabled` blocked)

## Why It Matters (Lead Quality / Job Conversion)
- prevents stale or synthetic-looking incident signals from entering buyer-proof opportunity flow as “fresh”
- makes source rollout and health state explicit in registry records, improving trust in which sources should drive real operator action
- reduces false confidence and protects downstream qualification/routing from degraded Tier-1 source inputs

## Exact Risk Areas Reviewed
- schema/runtime drift for source registry fields (`compliance_status` and rollout/readiness/health state)
- stale-vs-fresh incident timestamp handling and inferred timestamp inflation risk
- safe degraded behavior for live-configured incident sources returning empty results
- legacy/v2 coexistence impact: preserving existing route contracts and dashboard-compatible source summary shapes while adding new fields

## Tests Run
- `npm run typecheck`
- `npm test -- tests/v2-incidents-hardening.spec.ts tests/v2-firecrawl-incident-operator-flow.spec.ts tests/control-plane-readiness.spec.ts tests/buyer-readiness.spec.ts`
- `npm run build`

## Scope Guardrails
- no new source families
- no broad UX/product work
- no scoring/routing overhaul in this PR

## Next PR Slice (PR #40)
- scoring/routing quality improvements for the **same incident Tier-1 family only**:
  - confidence quality
  - urgency quality
  - territory relevance
  - false-positive reduction
  - operator credibility improvements
