### PR TITLE
PR #40: incident scoring/routing credibility hardening

### DIFF
--- a/src/lib/v2/connectors/runner.ts
+++ b/src/lib/v2/connectors/runner.ts
@@ -72,6 +72,70 @@ function responseWindowFromUrgency(urgency: number) {
   return "24-72h";
 }
 
+function clamp(value: number, min = 0, max = 100) {
+  return Math.max(min, Math.min(max, Math.round(value)));
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>;
+  return {};
+}
+
+function isIncidentFamilyEvent(event: ConnectorNormalizedEvent, opportunityType?: string) {
+  const normalized = `${event.eventType || ""} ${event.eventCategory || ""} ${opportunityType || ""}`.toLowerCase();
+  return normalized.includes("incident") || normalized.includes("fire") || normalized.includes("water") || normalized.includes("storm");
+}
+
+function territoryRelevanceFromEvent(event: ConnectorNormalizedEvent, geographyPrecision: number) {
+  const hasPoint = Number.isFinite(event.latitude) && Number.isFinite(event.longitude);
+  const hasPostal = Boolean(String(event.postalCode || "").trim());
+  const hasCityState = Boolean(String(event.city || "").trim() && String(event.state || "").trim());
+  if ((hasPoint && hasPostal) || geographyPrecision >= 88) return "high";
+  if (hasPoint || hasPostal || hasCityState || geographyPrecision >= 65) return "medium";
+  return "low";
+}
+
+function recommendIncidentNextAction({
+  event,
+  confidenceScore,
+  urgencyScore,
+  freshnessScore,
+  geographyPrecision
+}: {
+  event: ConnectorNormalizedEvent;
+  confidenceScore: number;
+  urgencyScore: number;
+  freshnessScore: number;
+  geographyPrecision: number;
+}) {
+  const territoryRelevance = territoryRelevanceFromEvent(event, geographyPrecision);
+
+  if (confidenceScore >= 75 && urgencyScore >= 80 && freshnessScore >= 70 && territoryRelevance === "high") {
+    return {
+      action: "dispatch_now",
+      reason: "high confidence incident with strong territory relevance and active urgency",
+      slaMinutes: 15,
+      territoryRelevance
+    };
+  }
+
+  if (confidenceScore >= 60 && freshnessScore >= 50 && territoryRelevance !== "low") {
+    return {
+      action: "verify_location_then_route",
+      reason: "credible incident signal requires quick location confirmation before dispatch",
+      slaMinutes: 30,
+      territoryRelevance
+    };
+  }
+
+  return {
+    action: "collect_secondary_signal",
+    reason: "low-confidence or weakly located incident should be validated before operator outreach",
+    slaMinutes: 60,
+    territoryRelevance
+  };
+}
+
 function classifyLikelyJobType(opportunityType: string, primaryServiceLine: string) {
   const normalized = `${opportunityType} ${primaryServiceLine}`.toLowerCase();
   if (normalized.includes("water") || normalized.includes("flood")) return "water mitigation";
@@ -98,36 +162,56 @@ function scoreInputsForEvent(
   options: {
     vertical?: FranchiseVertical;
     signalCategory?: string;
+    incidentFamily?: boolean;
   } = {}
 ) {
   const occurredAt = new Date(event.occurredAt).getTime();
   const now = Date.now();
   const minutes = Number.isFinite(occurredAt) ? Math.max(0, Math.round((now - occurredAt) / 60000)) : 120;
+  const normalized = asRecord(event.normalizedPayload);
+  const hasPoint = Number.isFinite(event.latitude) && Number.isFinite(event.longitude);
+  const hasPostal = Boolean(String(event.postalCode || "").trim());
+  const incidentFamily = Boolean(options.incidentFamily);
 
-  const geographyMatch = event.postalCode
+  const geographyMatch = hasPostal
     ? 92
-    : event.city && event.state
-      ? 80
-      : event.locationText
-        ? 68
-        : 35;
+    : hasPoint
+      ? 84
+      : event.city && event.state
+        ? 72
+        : event.locationText
+          ? 58
+          : 32;
 
-  const geographyPrecision = Number.isFinite(event.latitude) && Number.isFinite(event.longitude)
-    ? event.postalCode
+  const geographyPrecision = hasPoint
+    ? hasPostal
       ? 96
-      : 84
-    : event.postalCode
+      : 82
+    : hasPostal
       ? 78
-      : 48;
+      : 42;
 
   const serviceLineFit = (event.serviceLineCandidates?.length || 0) > 1 ? 84 : event.serviceLine ? 78 : 45;
+  const freshnessScore = toBoundedScore(normalized.data_freshness_score, deriveFreshnessScore(event.occurredAt));
+  const timestampConfidenceRaw = String(normalized.timestamp_confidence || "source").trim().toLowerCase();
+  const timestampConfidence = timestampConfidenceRaw === "source" ? 100 : timestampConfidenceRaw === "inferred" ? 52 : 72;
+  const sparseLocationPenalty = !hasPoint && !hasPostal ? 18 : !hasPoint ? 8 : 0;
+  const weakSignalPenalty = Number(event.supportingSignalsCount ?? 1) <= 1 ? 8 : 0;
+  const lowReliabilityPenalty = Number(event.sourceReliability ?? 50) < 50 ? 10 : 0;
+  const inferredPenalty = timestampConfidenceRaw === "inferred" ? 18 : 0;
+  const falsePositiveRisk = clamp(
+    sparseLocationPenalty + weakSignalPenalty + lowReliabilityPenalty + inferredPenalty - Math.min(14, freshnessScore / 8)
+  );
 
   return {
     sourceType: event.eventType,
     eventRecencyMinutes: minutes,
     severity: Number(event.severityHint ?? event.severity ?? 50),
-    geographyMatch,
-    geographyPrecision,
+    geographyMatch: incidentFamily && !hasPostal && !hasPoint ? Math.max(30, geographyMatch - 16) : geographyMatch,
+    geographyPrecision: incidentFamily && !hasPostal && !hasPoint ? Math.max(25, geographyPrecision - 18) : geographyPrecision,
+    freshnessScore,
+    timestampConfidence,
+    falsePositiveRisk,
     propertyTypeFit: 55,
     serviceLineFit,
     priorCustomerMatch: 40,
@@ -139,6 +223,33 @@ function scoreInputsForEvent(
     signalCategory: options.signalCategory,
     vertical: options.vertical
   };
+}
+
+function shouldSuppressIncidentOpportunity({
+  event,
+  confidenceScore,
+  freshnessScore,
+  falsePositiveRisk
+}: {
+  event: ConnectorNormalizedEvent;
+  confidenceScore: number;
+  freshnessScore: number;
+  falsePositiveRisk: number;
+}) {
+  if (!isIncidentFamilyEvent(event)) return { suppress: false, reason: "" };
+
+  const hasPreciseLocation = Boolean(String(event.postalCode || "").trim()) || (Number.isFinite(event.latitude) && Number.isFinite(event.longitude));
+  const lowSeverity = toBoundedScore(event.severityHint ?? event.severity, 50) < 45;
+  const sparseSignals = Number(event.supportingSignalsCount ?? 1) <= 1;
+
+  if (!hasPreciseLocation && freshnessScore <= 20 && falsePositiveRisk >= 55) {
+    return { suppress: true, reason: "low-location-confidence and stale incident signal" };
+  }
+  if (confidenceScore < 40 && (lowSeverity || sparseSignals)) {
+    return { suppress: true, reason: "weak incident confidence below suppression threshold" };
+  }
+
+  return { suppress: false, reason: "" };
 }
 
 async function resolveTenantVertical(supabase: SupabaseClient, tenantId: string) {
@@ -383,7 +494,9 @@ async function resolveOpportunityCandidate({
 }) {
   let query = supabase
     .from("v2_opportunities")
-    .select("id,urgency_score,job_likelihood_score,source_reliability_score,catastrophe_linkage_score,created_at,explainability_json,title,description")
+    .select(
+      "id,urgency_score,job_likelihood_score,source_reliability_score,catastrophe_linkage_score,incident_cluster_id,location,postal_code,created_at,explainability_json,title,description"
+    )
     .eq("tenant_id", tenantId)
     .eq("service_line", serviceLine)
     .order("created_at", { ascending: false })
@@ -416,7 +529,9 @@ async function loadOpportunityCandidateById({
 }) {
   const { data, error } = await supabase
     .from("v2_opportunities")
-    .select("id,urgency_score,job_likelihood_score,source_reliability_score,catastrophe_linkage_score,created_at,explainability_json,title,description")
+    .select(
+      "id,urgency_score,job_likelihood_score,source_reliability_score,catastrophe_linkage_score,incident_cluster_id,location,postal_code,created_at,explainability_json,title,description"
+    )
     .eq("tenant_id", tenantId)
     .eq("id", opportunityId)
     .maybeSingle();
@@ -438,25 +553,34 @@ function mergeOpportunityScores({
 }) {
   const explainability = (existing.explainability_json || {}) as Record<string, unknown>;
   const priorSignalCount = Math.max(1, Number(explainability.signal_count || 1));
-  const nextSignalCount = priorSignalCount + 1;
-
   const existingSourceTypes = Array.isArray(explainability.source_types)
-    ? explainability.source_types.map((v) => String(v))
+    ? explainability.source_types.map((v) => String(v).trim()).filter(Boolean)
     : [];
-  const sourceTypes = Array.from(new Set([...existingSourceTypes, sourceType]));
+  const normalizedSourceType = String(sourceType || "").trim().toLowerCase();
+  const existingNormalized = existingSourceTypes.map((value) => value.toLowerCase());
+  const isSameSourceTypeRepeat = normalizedSourceType ? existingNormalized.includes(normalizedSourceType) : false;
+  const sourceTypes = isSameSourceTypeRepeat
+    ? existingSourceTypes
+    : Array.from(new Set([...existingSourceTypes, String(sourceType || "").trim()])).filter(Boolean);
+  const nextSignalCount = isSameSourceTypeRepeat ? priorSignalCount : priorSignalCount + 1;
+  const agreementBoost = isSameSourceTypeRepeat ? 0 : Math.min(12, Math.max(0, (sourceTypes.length - 1) * 5));
+  const maxLift = isSameSourceTypeRepeat ? 2 : 10;
 
-  const agreementBoost = Math.min(12, Math.max(0, (sourceTypes.length - 1) * 5));
+  const weightedAverage = (current: unknown, next: number) => {
+    const currentValue = Number(current || 0);
+    const raw = Math.max(0, Math.min(100, Math.round((currentValue * priorSignalCount + next + agreementBoost) / nextSignalCount)));
+    return isSameSourceTypeRepeat ? Math.min(currentValue + maxLift, raw) : raw;
+  };
 
-  const weightedAverage = (current: unknown, next: number) =>
-    Math.max(0, Math.min(100, Math.round((Number(current || 0) * priorSignalCount + next + agreementBoost) / nextSignalCount)));
-
-  const confidenceScore = Math.max(
+  const priorConfidence = Number(explainability.confidence_score || incomingConfidence);
+  const rawConfidence = Math.max(
     0,
     Math.min(
       100,
-      Math.round(((Number(explainability.confidence_score || incomingConfidence) * priorSignalCount + incomingConfidence) / nextSignalCount + agreementBoost) / 1.05)
+      Math.round(((priorConfidence * priorSignalCount + incomingConfidence) / nextSignalCount + agreementBoost) / 1.05)
     )
   );
+  const confidenceScore = isSameSourceTypeRepeat ? Math.min(priorConfidence + maxLift, rawConfidence) : rawConfidence;
 
   return {
     urgencyScore: weightedAverage(existing.urgency_score, incoming.urgencyScore),
@@ -468,6 +592,37 @@ function mergeOpportunityScores({
     sourceTypes,
     multiSignal: nextSignalCount > 1 && sourceTypes.length > 1
   };
+}
+
+function shouldMergeIncidentCandidate({
+  candidate,
+  event,
+  clusterId,
+  eventCategory
+}: {
+  candidate: Record<string, unknown>;
+  event: ConnectorNormalizedEvent;
+  clusterId: string | null;
+  eventCategory: string;
+}) {
+  const explainability = asRecord(candidate.explainability_json);
+  const existingCategory = String(explainability.event_category || "");
+  if (existingCategory && existingCategory.toLowerCase() === eventCategory.toLowerCase()) return true;
+
+  const existingCluster = String(candidate.incident_cluster_id || "");
+  if (clusterId && existingCluster && existingCluster === clusterId) return true;
+
+  const existingPostal = String(candidate.postal_code || "").trim();
+  const incomingPostal = String(event.postalCode || "").trim();
+  if (existingPostal && incomingPostal && existingPostal === incomingPostal) return true;
+
+  const existingPoint = parseLatLngFromPoint(candidate.location);
+  if (existingPoint && Number.isFinite(event.latitude) && Number.isFinite(event.longitude)) {
+    const distance = haversineMeters(existingPoint.lat, existingPoint.lng, Number(event.latitude), Number(event.longitude));
+    if (distance <= 8_000) return true;
+  }
+
+  return false;
 }
 
 async function upsertOpportunityFromEvent({
@@ -494,16 +649,18 @@ async function upsertOpportunityFromEvent({
   const postalCode = String(event.postalCode || parsePostalFromText(String(event.locationText || "")) || "").trim();
   const likelyJobType = String(event.likelyJobType || classifyLikelyJobType(classification.opportunityType, primaryServiceLine));
   const signalCategory = resolveSignalCategory(event, classification.opportunityType);
+  const incidentFamily = isIncidentFamilyEvent(event, classification.opportunityType);
   const scoring = computeOpportunityScores(
     scoreInputsForEvent(event, 55, {
       vertical,
-      signalCategory
+      signalCategory,
+      incidentFamily
     })
   );
   const dedupInput = buildDedupInputForEvent(event, primaryServiceLine);
   const duplicate = await checkOpportunityDuplicate(supabase, tenantId, dedupInput, vertical);
 
-  const candidate =
+  let candidate =
     (duplicate.isDuplicate
       ? await loadOpportunityCandidateById({
           supabase,
@@ -518,6 +675,26 @@ async function upsertOpportunityFromEvent({
       postalCode: postalCode || null
     }));
 
+  if (incidentFamily && candidate?.id) {
+    const allowMerge = shouldMergeIncidentCandidate({
+      candidate,
+      event,
+      clusterId,
+      eventCategory: signalCategory
+    });
+    if (!allowMerge) candidate = null;
+  }
+
+  const incidentAction = incidentFamily
+    ? recommendIncidentNextAction({
+        event,
+        confidenceScore: scoring.confidenceScore,
+        urgencyScore: scoring.urgencyScore,
+        freshnessScore: Number(scoring.explainability.freshness_score || 0),
+        geographyPrecision: Number(scoring.explainability.geography_precision || 0)
+      })
+    : null;
+
   const baseExplainability = injectDedupKey(
     {
       ...scoring.explainability,
@@ -531,7 +708,13 @@ async function upsertOpportunityFromEvent({
       signal_count: 1,
       source_types: [event.eventType],
       multi_signal: false,
-      event_category: signalCategory
+      event_category: signalCategory,
+      incident_family: incidentFamily,
+      recommended_next_action: incidentAction?.action ?? "route_standard",
+      recommended_action_reason: incidentAction?.reason ?? "default routing path",
+      recommended_action_sla_minutes: incidentAction?.slaMinutes ?? 45,
+      territory_relevance: incidentAction?.territoryRelevance ?? "medium",
+      review_required: Boolean(incidentAction && incidentAction.action !== "dispatch_now")
     } as Record<string, unknown>,
     dedupInput
   );
@@ -701,7 +884,8 @@ export const connectorRunnerInternals = {
   resolveSignalCategory,
   resolveTenantVertical,
   scoreInputsForEvent,
-  upsertIncidentClusterFromEvent
+  upsertIncidentClusterFromEvent,
+  shouldSuppressIncidentOpportunity
 };
 
 export async function runConnectorForSource({
@@ -850,10 +1034,12 @@ export async function runConnectorForSource({
       const locationPoint = toPoint(event.latitude, event.longitude);
       const classification = connector.classify(event);
       const signalCategory = resolveSignalCategory(event, classification.opportunityType);
+      const incidentFamily = isIncidentFamilyEvent(event, classification.opportunityType);
       const eventScoring = computeOpportunityScores(
         scoreInputsForEvent(event, 50, {
           vertical,
-          signalCategory
+          signalCategory,
+          incidentFamily
         })
       );
 
@@ -886,6 +1072,17 @@ export async function runConnectorForSource({
 
       if (sourceEventError || !sourceEvent?.id) {
         throw new Error(sourceEventError?.message || "Failed writing source event");
+      }
+
+      const suppression = shouldSuppressIncidentOpportunity({
+        event,
+        confidenceScore: eventScoring.confidenceScore,
+        freshnessScore: Number(eventScoring.explainability.freshness_score || 0),
+        falsePositiveRisk: Number(eventScoring.explainability.false_positive_risk || 0)
+      });
+      if (suppression.suppress) {
+        invalidCount += 1;
+        continue;
       }
 
       const cluster = await upsertIncidentClusterFromEvent({

--- a/src/lib/v2/routing-engine.ts
+++ b/src/lib/v2/routing-engine.ts
@@ -143,14 +143,36 @@ function computeSlaMinutes({
   urgencyScore,
   catastropheLinkageScore,
   hasClusterMembership,
-  estimatedResponseWindow
+  estimatedResponseWindow,
+  confidenceScore,
+  freshnessScore,
+  geographyPrecision,
+  incidentFamily,
+  territoryRelevance
 }: {
   urgencyScore: number;
   catastropheLinkageScore: number;
   hasClusterMembership: boolean;
   estimatedResponseWindow: string;
+  confidenceScore?: number;
+  freshnessScore?: number;
+  geographyPrecision?: number;
+  incidentFamily?: boolean;
+  territoryRelevance?: string;
 }) {
   const responseWindow = estimatedResponseWindow.trim().toLowerCase();
+  const baseConfidence = Number.isFinite(confidenceScore) ? Number(confidenceScore) : 100;
+  const baseFreshness = Number.isFinite(freshnessScore) ? Number(freshnessScore) : 100;
+  const basePrecision = Number.isFinite(geographyPrecision) ? Number(geographyPrecision) : 100;
+  const relevance = String(territoryRelevance || "").trim().toLowerCase();
+
+  if (incidentFamily && (baseConfidence < 55 || baseFreshness < 45 || basePrecision < 55 || relevance === "low")) {
+    return 45;
+  }
+
+  if (incidentFamily && (baseConfidence < 65 || baseFreshness < 60 || basePrecision < 65 || relevance === "medium")) {
+    return 30;
+  }
 
   if (responseWindow === "0-4h" || urgencyScore >= 90) return 15;
   if (hasClusterMembership && catastropheLinkageScore >= 65) return 20;
@@ -171,6 +193,11 @@ function resolveRoutingInputs(opportunity: Record<string, unknown>) {
     catastropheLinkageScore: Number(opportunity.catastrophe_linkage_score || 0),
     hasClusterMembership: Boolean(opportunity.incident_cluster_id),
     estimatedResponseWindow: String(explainability.estimated_response_window || "24-72h"),
+    confidenceScore: Number(explainability.confidence_score || 0),
+    freshnessScore: Number(explainability.freshness_score || 0),
+    geographyPrecision: Number(explainability.geography_precision || 0),
+    incidentFamily: Boolean(explainability.incident_family),
+    territoryRelevance: String(explainability.territory_relevance || "unknown"),
     postalCode: String(opportunity.postal_code || parsePostalCode(String(opportunity.location_text || "")) || "") || null,
     latLng: parseLatLng(opportunity.location)
   };
@@ -276,7 +303,12 @@ async function computeDecision({
     urgencyScore,
     catastropheLinkageScore: catastrophe,
     hasClusterMembership,
-    estimatedResponseWindow
+    estimatedResponseWindow,
+    confidenceScore: input.confidenceScore,
+    freshnessScore: input.freshnessScore,
+    geographyPrecision: input.geographyPrecision,
+    incidentFamily: input.incidentFamily,
+    territoryRelevance: input.territoryRelevance
   });
 
   const { data: candidateRules } = await supabase
@@ -327,6 +359,10 @@ async function computeDecision({
   });
 
   if (territory) {
+    const territoryServiceLines = pickFirstStringArray(territory.service_lines);
+    const serviceLineMatch =
+      territoryServiceLines.length === 0 || territoryServiceLines.includes(serviceLine) || territoryServiceLines.includes("general");
+
     const pressure = await estimateCapacityPressure({
       supabase,
       assignedTenantId: tenantId
@@ -350,6 +386,16 @@ async function computeDecision({
       };
     }
 
+    if (!serviceLineMatch) {
+      return {
+        assignedTenantId: tenantId,
+        backupTenantId: backupTenant,
+        escalationTenantId: enterpriseTenantId,
+        reason: "territory_service_line_fallback",
+        slaMinutes: Math.max(45, baselineSlaMinutes)
+      };
+    }
+
     return {
       assignedTenantId: tenantId,
       backupTenantId: backupTenant,
@@ -369,7 +415,7 @@ async function computeDecision({
     assignedTenantId: tenantId,
     backupTenantId: fallbackBackup,
     escalationTenantId: enterpriseTenantId,
-    reason: "fallback",
+    reason: input.incidentFamily && (input.confidenceScore < 55 || input.territoryRelevance === "low") ? "manual_review_fallback" : "fallback",
     slaMinutes: Math.max(baselineSlaMinutes, 60)
   };
 }
@@ -428,6 +474,10 @@ export async function routeOpportunityV2({
         primary_service_line: primaryServiceLine,
         urgency_score: Number(opportunity.urgency_score || 0),
         catastrophe_linkage_score: Number(opportunity.catastrophe_linkage_score || 0),
+        confidence_score: Number(explainability.confidence_score || 0),
+        freshness_score: Number(explainability.freshness_score || 0),
+        geography_precision: Number(explainability.geography_precision || 0),
+        territory_relevance: String(explainability.territory_relevance || "unknown"),
         cluster_member: Boolean(opportunity.incident_cluster_id),
         estimated_response_window: estimatedResponseWindow
       }

--- a/src/lib/v2/scoring.ts
+++ b/src/lib/v2/scoring.ts
@@ -19,6 +19,9 @@ type ScoreInput = {
   sourceReliability: number;
   signalAgreement?: number;
   geographyPrecision?: number;
+  freshnessScore?: number;
+  timestampConfidence?: number;
+  falsePositiveRisk?: number;
   /** Optional: franchise vertical for vertical-aware scoring */
   vertical?: FranchiseVertical;
   /** Optional: signal category for preferred-signal boost */
@@ -55,24 +58,36 @@ export function computeOpportunityScores(input: ScoreInput): V2OpportunityScoreV
   const severityScore = clamp(adjustedSeverity + (input.vertical?.scoreModifiers.severityBoost ?? 0));
   const geographyScore = clamp(input.geographyMatch);
   const geographyPrecision = clamp(input.geographyPrecision ?? input.geographyMatch);
+  const freshnessScore = clamp(input.freshnessScore ?? recencyScore);
+  const timestampConfidence = clamp(input.timestampConfidence ?? 100);
+  const falsePositiveRisk = clamp(
+    input.falsePositiveRisk ??
+      (100 - geographyPrecision) * 0.4 + (100 - freshnessScore) * 0.35 + (100 - timestampConfidence) * 0.25
+  );
   const contactabilityScore = clamp(input.contactAvailability * 0.75 + input.priorCustomerMatch * 0.25);
   const signalAgreementScore = clamp(input.signalAgreement ?? Math.min(100, input.supportingSignalsCount * 16));
 
   const baseJobLikelihood = clamp(
     severityScore * 0.24 +
-      recencyScore * 0.19 +
+      recencyScore * 0.12 +
+      freshnessScore * 0.13 +
       geographyScore * 0.14 +
+      geographyPrecision * 0.05 +
       clamp(input.serviceLineFit) * 0.17 +
       clamp(input.propertyTypeFit) * 0.1 +
       clamp(input.supportingSignalsCount * 12) * 0.1 +
-      clamp(input.priorCustomerMatch) * 0.06
+      clamp(input.priorCustomerMatch) * 0.06 -
+      falsePositiveRisk * 0.07
   );
 
   const baseUrgency = clamp(
-    severityScore * 0.42 +
-      recencyScore * 0.3 +
+    severityScore * 0.35 +
+      recencyScore * 0.18 +
+      freshnessScore * 0.2 +
       clamp(input.catastropheSignal) * 0.18 +
-      sourceUrgencyBoost(input.sourceType)
+      timestampConfidence * 0.07 +
+      sourceUrgencyBoost(input.sourceType) -
+      falsePositiveRisk * 0.08
   );
 
   // Apply vertical modifiers (seasonal, preferred signal boost, multipliers)
@@ -90,11 +105,14 @@ export function computeOpportunityScores(input: ScoreInput): V2OpportunityScoreV
   const catastropheLinkageScore = clamp(input.catastropheSignal * 0.8 + severityScore * 0.2);
   const sourceReliabilityScore = clamp(input.sourceReliability);
   const confidenceScore = clamp(
-    sourceReliabilityScore * 0.35 +
-      recencyScore * 0.2 +
-      signalAgreementScore * 0.2 +
-      geographyPrecision * 0.15 +
-      severityScore * 0.1
+    sourceReliabilityScore * 0.28 +
+      recencyScore * 0.12 +
+      freshnessScore * 0.2 +
+      signalAgreementScore * 0.16 +
+      geographyPrecision * 0.14 +
+      timestampConfidence * 0.1 +
+      severityScore * 0.08 -
+      falsePositiveRisk * 0.08
   );
 
   const blendedRevenueSignal = clamp(jobLikelihoodScore * 0.62 + urgencyScore * 0.18 + contactabilityScore * 0.2);
@@ -113,6 +131,9 @@ export function computeOpportunityScores(input: ScoreInput): V2OpportunityScoreV
       severity: severityScore,
       geography_match: geographyScore,
       geography_precision: geographyPrecision,
+      freshness_score: freshnessScore,
+      timestamp_confidence: timestampConfidence,
+      false_positive_risk: falsePositiveRisk,
       property_type_fit: clamp(input.propertyTypeFit),
       service_line_fit: clamp(input.serviceLineFit),
       prior_customer_match: clamp(input.priorCustomerMatch),

--- a/tests/v2-firecrawl-incident-operator-flow.spec.ts
+++ b/tests/v2-firecrawl-incident-operator-flow.spec.ts
@@ -237,9 +237,289 @@ test("Firecrawl-backed incident source creates an operator-facing opportunity", 
     expect(typeof explainability.signal_count).toBe("number");
     expect(Array.isArray(explainability.source_types)).toBeTruthy();
     expect(typeof explainability.event_category).toBe("string");
+    expect(typeof explainability.recommended_next_action).toBe("string");
+    expect(typeof explainability.recommended_action_reason).toBe("string");
+    expect(typeof explainability.recommended_action_sla_minutes).toBe("number");
+    expect(typeof explainability.territory_relevance).toBe("string");
     expect(String((sourceEvents[0]?.normalized_payload as Record<string, unknown>)?.source_provenance || "")).toBe(
       "https://county.example.gov/incidents/flood-response"
     );
+    expect(signals.length).toBeGreaterThan(0);
+    expect(auditEvents.length).toBeGreaterThan(0);
+  } finally {
+    (globalThis as typeof globalThis & { fetch: typeof fetch }).fetch = previousFetch;
+
+    if (previousSupabaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = previousSupabaseUrl;
+    }
+
+    if (previousServiceRoleKey === undefined) {
+      delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    } else {
+      process.env.SUPABASE_SERVICE_ROLE_KEY = previousServiceRoleKey;
+    }
+  }
+});
+
+test("near-duplicate Firecrawl incident records do not inflate opportunity priority", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const previousServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+
+  const connectorRuns: Array<Record<string, unknown>> = [];
+  const sourceEvents: Array<Record<string, unknown>> = [];
+  const opportunities: Array<Record<string, unknown>> = [];
+  const signals: Array<Record<string, unknown>> = [];
+  const auditEvents: Array<Record<string, unknown>> = [];
+
+  const pageResponses = [
+    {
+      title: "County flood response bulletin",
+      description: "Basement flooding and emergency response activity",
+      sourceURL: "https://county.example.gov/incidents/flood-response-a"
+    },
+    {
+      title: "County flood response bulletin update",
+      description: "Basement flooding and emergency response activity nearby",
+      sourceURL: "https://county.example.gov/incidents/flood-response-b"
+    }
+  ];
+
+  let firecrawlCall = 0;
+
+  (globalThis as typeof globalThis & { fetch: typeof fetch }).fetch = async (input, init) => {
+    const url = String(input);
+
+    if (url === "https://api.firecrawl.dev/v2/scrape") {
+      const index = Math.min(firecrawlCall, pageResponses.length - 1);
+      const payload = pageResponses[index]!;
+      firecrawlCall += 1;
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            markdown: "Emergency crews on scene after basement flooding from a water main break.",
+            metadata: {
+              title: payload.title,
+              description: payload.description,
+              sourceURL: payload.sourceURL,
+              publishedTime: new Date().toISOString()
+            }
+          }
+        }),
+        {
+          headers: {
+            "content-type": "application/json"
+          }
+        }
+      );
+    }
+
+    if (url.includes("/rest/v1/v2_audit_logs")) {
+      auditEvents.push(JSON.parse(String(init?.body || "{}")) as Record<string, unknown>);
+      return new Response(JSON.stringify([{ id: "audit-1" }]), {
+        status: 201,
+        headers: { "content-type": "application/json" }
+      });
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+
+  const supabaseMock = {
+    from(table: string) {
+      if (table === "v2_connector_runs") {
+        return {
+          insert: (payload: Record<string, unknown>) => ({
+            select: () => ({
+              single: async () => {
+                const row = { id: `run-${connectorRuns.length + 1}`, ...payload };
+                connectorRuns.push(row);
+                return { data: row, error: null };
+              }
+            })
+          }),
+          update: (patch: Record<string, unknown>) => ({
+            eq: async (_field: string, value: unknown) => {
+              const index = connectorRuns.findIndex((row) => String(row.id) === String(value));
+              if (index >= 0) connectorRuns[index] = { ...connectorRuns[index], ...patch };
+              return { data: null, error: null };
+            }
+          })
+        };
+      }
+
+      if (table === "v2_tenants") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: { settings_json: { vertical: "restoration" } },
+                error: null
+              })
+            })
+          })
+        };
+      }
+
+      if (table === "v2_source_events") {
+        return {
+          upsert: (payload: Record<string, unknown>) => ({
+            select: () => ({
+              single: async () => {
+                const row = { id: `event-${sourceEvents.length + 1}`, ...payload };
+                sourceEvents.push(row);
+                return { data: row, error: null };
+              }
+            })
+          })
+        };
+      }
+
+      if (table === "v2_opportunities") {
+        const state = {
+          tenantId: "",
+          serviceLine: "",
+          id: "",
+          postalCode: ""
+        };
+
+        const selectBuilder = {
+          eq(field: string, value: unknown) {
+            if (field === "tenant_id") state.tenantId = String(value || "");
+            if (field === "service_line") state.serviceLine = String(value || "");
+            if (field === "id") state.id = String(value || "");
+            if (field === "postal_code") state.postalCode = String(value || "");
+            return selectBuilder;
+          },
+          gte() {
+            return selectBuilder;
+          },
+          not() {
+            return selectBuilder;
+          },
+          contains() {
+            return selectBuilder;
+          },
+          order() {
+            return selectBuilder;
+          },
+          limit() {
+            return selectBuilder;
+          },
+          maybeSingle: async () => {
+            const match = opportunities.find((row) => String(row.id) === state.id && String(row.tenant_id) === state.tenantId) || null;
+            return { data: match, error: null };
+          },
+          then(resolve: (value: { data: Array<Record<string, unknown>>; error: null }) => unknown, reject?: (reason: unknown) => unknown) {
+            let rows = opportunities.filter((row) => String(row.tenant_id) === state.tenantId);
+            if (state.serviceLine) rows = rows.filter((row) => String(row.service_line) === state.serviceLine);
+            if (state.postalCode) rows = rows.filter((row) => String(row.postal_code) === state.postalCode);
+            return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+          }
+        };
+
+        return {
+          select: () => selectBuilder,
+          insert: (payload: Record<string, unknown>) => ({
+            select: () => ({
+              single: async () => {
+                const row = {
+                  id: `opp-${opportunities.length + 1}`,
+                  created_at: new Date().toISOString(),
+                  ...payload
+                };
+                opportunities.push(row);
+                return { data: row, error: null };
+              }
+            })
+          }),
+          update: (patch: Record<string, unknown>) => ({
+            eq: (_field: string, value: unknown) => ({
+              select: () => ({
+                single: async () => {
+                  const index = opportunities.findIndex((row) => String(row.id) === String(value));
+                  if (index >= 0) {
+                    opportunities[index] = { ...opportunities[index], ...patch };
+                    return { data: { id: opportunities[index]?.id }, error: null };
+                  }
+                  return { data: null, error: { message: "Opportunity not found" } };
+                }
+              })
+            })
+          })
+        };
+      }
+
+      if (table === "v2_opportunity_signals") {
+        return {
+          insert: async (payload: Array<Record<string, unknown>>) => {
+            signals.push(...payload);
+            return { data: null, error: null };
+          }
+        };
+      }
+
+      if (table === "v2_incident_clusters") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                eq: () => ({
+                  order: () => ({
+                    limit: async () => ({ data: [], error: null })
+                  })
+                })
+              })
+            })
+          }),
+          update: () => ({
+            eq: async () => ({ data: null, error: null })
+          }),
+          insert: () => ({
+            select: () => ({
+              single: async () => ({ data: { id: "cluster-1" }, error: null })
+            })
+          })
+        };
+      }
+
+      throw new Error(`Unexpected table access: ${table}`);
+    }
+  };
+
+  try {
+    const result = await runConnectorForSource({
+      supabase: supabaseMock as never,
+      tenantId: "tenant-1",
+      sourceId: "source-incident-dup",
+      sourceType: "incident",
+      sourceConfig: {
+        source_name: "County Incidents",
+        terms_status: "approved",
+        use_firecrawl: true,
+        max_event_age_hours: 9999,
+        firecrawl_api_key: "fc-test-key",
+        page_urls: [pageResponses[0]!.sourceURL, pageResponses[1]!.sourceURL],
+        location_text: "Buffalo, NY"
+      },
+      actorUserId: "user-1",
+      connector: incidentConnector
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.recordsCreated).toBe(2);
+    expect(sourceEvents).toHaveLength(2);
+    expect(opportunities).toHaveLength(1);
+    const explainability = (opportunities[0]?.explainability_json as Record<string, unknown>) || {};
+    expect(explainability.signal_count).toBe(1);
+    expect(explainability.multi_signal).toBeFalsy();
+    expect(Number(explainability.confidence_score || 0)).toBeLessThanOrEqual(100);
     expect(signals.length).toBeGreaterThan(0);
     expect(auditEvents.length).toBeGreaterThan(0);
   } finally {

--- a/tests/v2-multi-signal-scoring.spec.ts
+++ b/tests/v2-multi-signal-scoring.spec.ts
@@ -131,3 +131,147 @@ test("runner builds address-level dedup input from normalized connector events",
     sourceType: "permit.city"
   });
 });
+
+test("score merge does not inflate signal count for repeated source type", () => {
+  const incoming = computeOpportunityScores({
+    sourceType: "incidents.generic",
+    eventRecencyMinutes: 12,
+    severity: 80,
+    geographyMatch: 84,
+    geographyPrecision: 84,
+    propertyTypeFit: 60,
+    serviceLineFit: 84,
+    priorCustomerMatch: 30,
+    contactAvailability: 50,
+    supportingSignalsCount: 2,
+    catastropheSignal: 74,
+    sourceReliability: 72,
+    signalAgreement: 80
+  });
+
+  const merged = connectorRunnerInternals.mergeOpportunityScores({
+    existing: {
+      urgency_score: 76,
+      job_likelihood_score: 70,
+      source_reliability_score: 75,
+      catastrophe_linkage_score: 68,
+      explainability_json: {
+        signal_count: 1,
+        confidence_score: 72,
+        source_types: ["incidents.generic"]
+      }
+    },
+    incoming,
+    incomingConfidence: incoming.confidenceScore,
+    sourceType: "incidents.generic"
+  });
+
+  expect(merged.signalCount).toBe(1);
+  expect(merged.sourceTypes).toEqual(["incidents.generic"]);
+});
+
+test("runner score inputs carry incident timestamp and freshness context", () => {
+  const input = connectorRunnerInternals.scoreInputsForEvent(
+    {
+      occurredAt: "2026-03-20T12:00:00.000Z",
+      dedupeKey: "incident-1",
+      eventType: "incidents.generic",
+      eventCategory: "water_incident",
+      title: "Water incident",
+      locationText: "Somewhere in NY",
+      serviceLine: "restoration",
+      supportingSignalsCount: 1,
+      sourceReliability: 40,
+      normalizedPayload: {
+        timestamp_confidence: "inferred",
+        data_freshness_score: 24
+      },
+      rawPayload: {}
+    },
+    50,
+    {
+      incidentFamily: true
+    }
+  );
+
+  expect(input.timestampConfidence).toBe(52);
+  expect(input.freshnessScore).toBe(24);
+  expect(input.falsePositiveRisk).toBeGreaterThanOrEqual(40);
+  expect(input.geographyPrecision).toBeLessThan(40);
+});
+
+test("weak inferred incident signals produce lower confidence than sourced signals", () => {
+  const sourced = computeOpportunityScores({
+    sourceType: "incidents.generic",
+    eventRecencyMinutes: 20,
+    severity: 74,
+    geographyMatch: 78,
+    geographyPrecision: 80,
+    propertyTypeFit: 60,
+    serviceLineFit: 76,
+    priorCustomerMatch: 24,
+    contactAvailability: 48,
+    supportingSignalsCount: 2,
+    catastropheSignal: 68,
+    sourceReliability: 76,
+    signalAgreement: 78
+  });
+
+  const inferredWeak = computeOpportunityScores({
+    sourceType: "incidents.generic",
+    eventRecencyMinutes: 20,
+    severity: 74,
+    geographyMatch: 78,
+    geographyPrecision: 40,
+    propertyTypeFit: 60,
+    serviceLineFit: 76,
+    priorCustomerMatch: 24,
+    contactAvailability: 48,
+    supportingSignalsCount: 1,
+    catastropheSignal: 68,
+    sourceReliability: 42,
+    signalAgreement: 38
+  });
+
+  expect(inferredWeak.confidenceScore).toBeLessThan(sourced.confidenceScore);
+  expect(inferredWeak.explainability.signal_agreement).toBe(38);
+});
+
+test("score merge does not increase signal count when incoming source type already exists", () => {
+  const incoming = computeOpportunityScores({
+    sourceType: "incidents.generic",
+    eventRecencyMinutes: 12,
+    severity: 80,
+    geographyMatch: 84,
+    geographyPrecision: 84,
+    propertyTypeFit: 60,
+    serviceLineFit: 84,
+    priorCustomerMatch: 30,
+    contactAvailability: 50,
+    supportingSignalsCount: 2,
+    catastropheSignal: 74,
+    sourceReliability: 72,
+    signalAgreement: 80
+  });
+
+  const merged = connectorRunnerInternals.mergeOpportunityScores({
+    existing: {
+      urgency_score: 76,
+      job_likelihood_score: 70,
+      source_reliability_score: 75,
+      catastrophe_linkage_score: 68,
+      explainability_json: {
+        signal_count: 1,
+        confidence_score: 72,
+        source_types: ["incidents.generic"]
+      }
+    },
+    incoming,
+    incomingConfidence: incoming.confidenceScore,
+    sourceType: "incidents.generic"
+  });
+
+  expect(merged.sourceTypes.filter((value) => value === "incidents.generic")).toHaveLength(1);
+  expect(merged.signalCount).toBe(1);
+  expect(merged.multiSignal).toBeFalsy();
+});

--- a/tests/v2-scoring.spec.ts
+++ b/tests/v2-scoring.spec.ts
@@ -97,3 +97,88 @@ test("v2 scoring applies vertical and preferred-signal modifiers when supplied",
   expect(restorationStorm.explainability.vertical_key).toBe("restoration");
   expect(restorationStorm.explainability.preferred_signal).toBeTruthy();
 });
+
+test("fresh severe local incident ranks above stale weak incident", () => {
+  const staleWeak = computeOpportunityScores({
+    sourceType: "incidents.generic",
+    eventRecencyMinutes: 72 * 60,
+    severity: 28,
+    geographyMatch: 35,
+    propertyTypeFit: 45,
+    serviceLineFit: 50,
+    priorCustomerMatch: 15,
+    contactAvailability: 30,
+    supportingSignalsCount: 1,
+    catastropheSignal: 20,
+    sourceReliability: 55,
+    freshnessScore: 15,
+    timestampConfidence: 52,
+    falsePositiveRisk: 65
+  });
+
+  const freshSevereLocal = computeOpportunityScores({
+    sourceType: "incidents.generic",
+    eventRecencyMinutes: 10,
+    severity: 92,
+    geographyMatch: 92,
+    propertyTypeFit: 70,
+    serviceLineFit: 88,
+    priorCustomerMatch: 30,
+    contactAvailability: 55,
+    supportingSignalsCount: 3,
+    catastropheSignal: 86,
+    sourceReliability: 70,
+    freshnessScore: 92,
+    timestampConfidence: 100,
+    falsePositiveRisk: 12
+  });
+
+  const rank = { low: 0, medium: 1, high: 2, enterprise: 3 } as const;
+  expect(freshSevereLocal.urgencyScore).toBeGreaterThan(staleWeak.urgencyScore);
+  expect(freshSevereLocal.jobLikelihoodScore).toBeGreaterThan(staleWeak.jobLikelihoodScore);
+  expect(freshSevereLocal.confidenceScore).toBeGreaterThan(staleWeak.confidenceScore);
+  expect(rank[freshSevereLocal.revenueBand]).toBeGreaterThan(rank[staleWeak.revenueBand]);
+});
+
+test("inferred timestamp lowers incident confidence even with similar recency", () => {
+  const sourced = computeOpportunityScores({
+    sourceType: "incidents.generic",
+    eventRecencyMinutes: 20,
+    severity: 74,
+    geographyMatch: 78,
+    geographyPrecision: 80,
+    propertyTypeFit: 60,
+    serviceLineFit: 76,
+    priorCustomerMatch: 24,
+    contactAvailability: 48,
+    supportingSignalsCount: 2,
+    catastropheSignal: 68,
+    sourceReliability: 76,
+    signalAgreement: 78,
+    freshnessScore: 84,
+    timestampConfidence: 100,
+    falsePositiveRisk: 20
+  });
+
+  const inferred = computeOpportunityScores({
+    sourceType: "incidents.generic",
+    eventRecencyMinutes: 20,
+    severity: 74,
+    geographyMatch: 78,
+    geographyPrecision: 40,
+    propertyTypeFit: 60,
+    serviceLineFit: 76,
+    priorCustomerMatch: 24,
+    contactAvailability: 48,
+    supportingSignalsCount: 1,
+    catastropheSignal: 68,
+    sourceReliability: 42,
+    signalAgreement: 38,
+    freshnessScore: 34,
+    timestampConfidence: 52,
+    falsePositiveRisk: 68
+  });
+
+  expect(inferred.confidenceScore).toBeLessThan(sourced.confidenceScore);
+  expect(Number(inferred.explainability.timestamp_confidence)).toBeLessThan(Number(sourced.explainability.timestamp_confidence));
+});

--- a/tests/v2-territory-routing.spec.ts
+++ b/tests/v2-territory-routing.spec.ts
@@ -190,3 +190,86 @@ test("routing intelligence inputs prefer primary service line and tighten SLA fo
 
   expect(slaMinutes).toBe(15);
 });
+
+test("incident low-confidence context prevents ultra-fast SLA despite urgency", () => {
+  const slaMinutes = routingInternals.computeSlaMinutes({
+    urgencyScore: 93,
+    catastropheLinkageScore: 82,
+    hasClusterMembership: true,
+    estimatedResponseWindow: "0-4h",
+    incidentFamily: true,
+    confidenceScore: 44,
+    freshnessScore: 30,
+    geographyPrecision: 40,
+    territoryRelevance: "low"
+  });
+
+  expect(slaMinutes).toBe(45);
+});
+
+test("incident high-confidence high-relevance context keeps fast SLA", () => {
+  const slaMinutes = routingInternals.computeSlaMinutes({
+    urgencyScore: 93,
+    catastropheLinkageScore: 82,
+    hasClusterMembership: true,
+    estimatedResponseWindow: "0-4h",
+    incidentFamily: true,
+    confidenceScore: 86,
+    freshnessScore: 90,
+    geographyPrecision: 92,
+    territoryRelevance: "high"
+  });
+
+  expect(slaMinutes).toBe(15);
+});
+
+test("zip routing prefers exact service-line territory over non-matching rows", async () => {
+  const original = featureFlags.usePolygonRouting;
+  (featureFlags as { usePolygonRouting: boolean }).usePolygonRouting = false;
+
+  const { mock } = createTerritorySupabaseMock({
+    rows: [
+      {
+        id: "t-nonmatch",
+        tenant_id: "tenant-1",
+        zip_codes: ["10001"],
+        service_lines: ["electrical"],
+        capacity_json: {},
+        hours_json: {}
+      },
+      {
+        id: "t-match",
+        tenant_id: "tenant-1",
+        zip_codes: ["10001"],
+        service_lines: ["restoration"],
+        capacity_json: {},
+        hours_json: {}
+      }
+    ],
+    polygonTerritoryId: null
+  });
+
+  const territory = await findTerritoryForOpportunity({
+    supabase: mock,
+    tenantId: "tenant-1",
+    postalCode: "10001",
+    serviceLine: "restoration",
+    latitude: null,
+    longitude: null
+  });
+
+  expect(territory?.id).toBe("t-match");
+
+  (featureFlags as { usePolygonRouting: boolean }).usePolygonRouting = original;
+});
+
+test("routing inputs extract postal code from location text when explicit postal is missing", () => {
+  const input = routingInternals.resolveRoutingInputs({
+    service_line: "restoration",
+    location_text: "Albany, NY 12207",
+    location: null,
+    explainability_json: {}
+  });
+
+  expect(input.postalCode).toBe("12207");
+});


### PR DESCRIPTION
## What changed
- Tightened incident-family scoring inputs to account for freshness, timestamp confidence, geography precision, and false-positive risk.
- Added incident suppression guardrails for weak/stale/low-location-confidence signals before opportunity creation.
- Hardened merge behavior so repeated same-source signals do not inflate priority/signal count, and incident candidate merges require category/cluster/geography affinity.
- Added incident-aware recommended action fields to explainability (action, reason, SLA hint, territory relevance, review requirement).
- Updated routing SLA discipline to slow down low-confidence/low-freshness/low-precision incident opportunities and to surface service-line/territory fallback reasons.
- Added targeted regression tests for stale-vs-fresh ranking, inferred-signal downgrading, duplicate inflation suppression, routing SLA guard behavior, and operator-facing output shape.

## Why this matters
These changes directly reduce false positives and priority inflation in incident opportunities, while making routing urgency and next actions more explainable and operator-credible.

## Exact risk areas reviewed
- Incident confidence inflation from inferred timestamps.
- Duplicate/near-duplicate score inflation when source types repeat.
- Incident merges across weakly-related categories/geographies.
- Over-aggressive SLA/routing on low-confidence incident signals.
- Opportunity explainability completeness for operator actionability.

## Tests run
- npm run typecheck
- npm test -- tests/v2-scoring.spec.ts tests/v2-multi-signal-scoring.spec.ts tests/v2-territory-routing.spec.ts tests/v2-firecrawl-incident-operator-flow.spec.ts
- npm run build

## Next slice
PR #41: operator queue + review/assignment + convert-to-job workflow for incident opportunities hardened in PRs #39/#40.