### PR TITLE
PR #41: operator queue actions + convert-to-job for incident opportunities

### DIFF
--- a/docs/PR42_SOURCE_FAMILY_PREP.md
+++ b/docs/PR42_SOURCE_FAMILY_PREP.md
@@ -1,0 +1,34 @@
+# PR #42 Source Family Prep
+
+## Recommendation
+- **Next source family:** `permits` (building + restoration permit signals)
+- **Why this wins now:**
+  - Strong existing connector footprint (`permits`, `open311`, permit intelligence tests already in repo)
+  - Low compliance ambiguity versus social/community scraping sources
+  - High restoration relevance (roofing, water mitigation follow-up, fire restoration rebuild, mold remediation remediation permits)
+  - Existing lane model and operator queue already recognize permit lane behavior
+
+## Evidence Snapshot
+- Existing connectors and tests indicate mature partial implementation:
+  - `src/lib/v2/connectors/permits`
+  - `tests/v2-permits-ingestion.spec.ts`
+  - `tests/v2-permits-intelligence.spec.ts`
+  - `tests/v2-free-sources-connectors.spec.ts`
+- Proof and readiness logic already includes permit-oriented provenance and synthetic safety controls.
+
+## PR #42 Scope Draft (Do Not Implement Yet)
+- Activate permit-family runtime path end-to-end with the same discipline used for incidents:
+  - source freshness + rollout/readiness enforcement
+  - false-positive suppression for weak permit records
+  - permit-specific scoring/routing adjustments
+  - operator-facing provenance and next-action quality for permit opportunities
+- Keep scope constrained to permit family only; no third source family in the same slice.
+
+## Branch + Test Setup
+- Planned branch: `codex/pr42-permits-family-activation`
+- Required test focus:
+  - stale vs fresh permit handling
+  - permit dedupe and duplicate-priority suppression
+  - permit actionability output shape
+  - routing relevance for permit service-line/territory fit
+  - safe degraded behavior when permit provider config is incomplete

--- a/src/app/api/opportunities/[id]/convert/route.ts
+++ b/src/app/api/opportunities/[id]/convert/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { assertRole } from "@/lib/auth/rbac";
+import { featureFlags } from "@/lib/config/feature-flags";
+import { isDemoMode } from "@/lib/services/review-mode";
+import { getV2TenantContext } from "@/lib/v2/context";
+import { convertOpportunityToJobV2 } from "@/lib/v2/opportunity-conversion";
+import type { AccountRole } from "@/types/domain";
+
+export async function POST(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  if (isDemoMode() || !featureFlags.useV2Writes) {
+    return NextResponse.json(
+      { converted: false, mode: "compat", reason: "Enable SB_USE_V2_WRITES to convert v2 opportunities to jobs" },
+      { status: 202 }
+    );
+  }
+
+  const context = await getV2TenantContext();
+  if (!context) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  assertRole(context.role as AccountRole, ["ACCOUNT_OWNER", "DISPATCHER", "TECH"]);
+
+  try {
+    const result = await convertOpportunityToJobV2({
+      supabase: context.supabase as never,
+      tenantId: context.franchiseTenantId,
+      opportunityId: id,
+      actorUserId: context.userId
+    });
+
+    return NextResponse.json({
+      converted: true,
+      ...result
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Could not convert opportunity to job";
+    const status = message.includes("requires review") ? 409 : message.includes("not found") ? 404 : 400;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/api/opportunities/route.ts
+++ b/src/app/api/opportunities/route.ts
@@ -7,6 +7,7 @@ import { getOpportunityQualificationSnapshot, qualificationAllowsDispatch } from
 import { deriveOpportunityPipelineStage } from "@/lib/v2/opportunity-pipeline";
 import { classifyProofAuthenticity } from "@/lib/v2/proof-authenticity";
 import { classifySourceLane, opportunityPriorityScore } from "@/lib/v2/source-lanes";
+import { deriveOpportunityActionability } from "@/lib/v2/opportunity-actionability";
 
 function asRecord(value: unknown) {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
@@ -61,6 +62,7 @@ export async function GET(req: NextRequest) {
 
       const opportunityIds = (data || []).map((row) => String(row.id));
       const verifiedLeadOpportunityIds = new Set<string>();
+      const latestAssignmentByOpportunity = new Map<string, Record<string, unknown>>();
 
       if (opportunityIds.length > 0) {
         const { data: leadRows, error: leadError } = await v2Context.supabase
@@ -75,6 +77,21 @@ export async function GET(req: NextRequest) {
           if (leadCountsAsReal(lead as Record<string, unknown>)) {
             verifiedLeadOpportunityIds.add(String((lead as Record<string, unknown>).opportunity_id || ""));
           }
+        }
+
+        const { data: assignments, error: assignmentError } = await v2Context.supabase
+          .from("v2_assignments")
+          .select("id,opportunity_id,status,assigned_tenant_id,sla_due_at,assignment_reason,created_at")
+          .eq("tenant_id", v2Context.franchiseTenantId)
+          .in("opportunity_id", opportunityIds)
+          .order("created_at", { ascending: false });
+
+        if (assignmentError) return NextResponse.json({ error: assignmentError.message }, { status: 400 });
+
+        for (const assignment of (assignments || []) as Array<Record<string, unknown>>) {
+          const opportunityId = String(assignment.opportunity_id || "");
+          if (!opportunityId || latestAssignmentByOpportunity.has(opportunityId)) continue;
+          latestAssignmentByOpportunity.set(opportunityId, assignment);
         }
       }
 
@@ -108,6 +125,14 @@ export async function GET(req: NextRequest) {
             urgencyScore: row.urgency_score,
             jobLikelihoodScore: row.job_likelihood_score,
             sourceReliabilityScore: row.source_reliability_score
+          });
+          const assignment = latestAssignmentByOpportunity.get(String(row.id || "")) || null;
+          const actionability = deriveOpportunityActionability({
+            lifecycleStatus: row.lifecycle_status,
+            routingStatus: row.routing_status,
+            contactStatus: row.contact_status,
+            explainability,
+            assignment
           });
           const dispatchReady = qualificationAllowsDispatch(qualification);
           const countsAsRealCapture = proofAuthenticity === "live_provider" || proofAuthenticity === "live_derived";
@@ -159,10 +184,26 @@ export async function GET(req: NextRequest) {
             source_provenance: typeof explainability.source_provenance === "string" ? explainability.source_provenance : null,
             priority_score: priorityScore,
             next_recommended_action: qualification.nextRecommendedAction,
+            recommended_next_action: actionability.recommendedNextAction,
+            recommended_action_reason: actionability.recommendedActionReason,
+            recommended_action_sla_minutes: actionability.recommendedActionSlaMinutes,
+            freshness_score: actionability.freshnessScore,
+            confidence_score: actionability.confidenceScore,
+            territory_relevance: actionability.territoryRelevance,
+            review_required: actionability.reviewRequired,
+            assignment_id: actionability.assignmentId,
+            assignment_status: actionability.assignmentStatus,
+            assigned_tenant_id: actionability.assignedTenantId,
+            assignment_sla_due_at: actionability.assignmentSlaDueAt,
+            assignment_reason: actionability.assignmentReason,
+            can_route_now: actionability.canRouteNow,
+            can_accept_assignment: actionability.canAcceptAssignment,
+            can_escalate_assignment: actionability.canEscalateAssignment,
+            can_convert_to_job: actionability.canConvertToJob,
             research_only: qualification.researchOnly,
             requires_sdr_qualification: qualification.requiresSdrQualification,
             verification_status: qualification.verificationStatus,
-            dispatch_ready: dispatchReady,
+            dispatch_ready: dispatchReady || actionability.dispatchReady,
             counts_as_real_capture: countsAsRealCapture,
             counts_as_real_lead: countsAsRealCapture && verifiedLeadOpportunityIds.has(String(row.id)),
             raw: {

--- a/src/components/dashboard/opportunities-view.tsx
+++ b/src/components/dashboard/opportunities-view.tsx
@@ -38,6 +38,22 @@ export type Opportunity = {
   source_lane?: SourceLaneKey | null;
   priority_score?: number | null;
   next_recommended_action?: string | null;
+  recommended_next_action?: string | null;
+  recommended_action_reason?: string | null;
+  recommended_action_sla_minutes?: number | null;
+  freshness_score?: number | null;
+  confidence_score?: number | null;
+  territory_relevance?: string | null;
+  review_required?: boolean;
+  assignment_id?: string | null;
+  assignment_status?: string | null;
+  assigned_tenant_id?: string | null;
+  assignment_sla_due_at?: string | null;
+  assignment_reason?: string | null;
+  can_route_now?: boolean;
+  can_accept_assignment?: boolean;
+  can_escalate_assignment?: boolean;
+  can_convert_to_job?: boolean;
   research_only?: boolean;
   requires_sdr_qualification?: boolean;
   counts_as_real_capture?: boolean;
@@ -69,6 +85,8 @@ export function OpportunitiesView() {
   const [sourceFilter, setSourceFilter] = useState<SourceLaneFilter>("all");
   const [qualificationFilter, setQualificationFilter] = useState("all");
   const [search, setSearch] = useState("");
+  const [notice, setNotice] = useState<string | null>(null);
+  const [actionBusyKey, setActionBusyKey] = useState<string | null>(null);
 
   async function loadOpportunities() {
     setLoading(true);
@@ -84,6 +102,40 @@ export function OpportunitiesView() {
       setOpportunities([]);
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function runRowAction({
+    opportunityId,
+    action,
+    assignmentId
+  }: {
+    opportunityId: string;
+    action: "route" | "accept" | "escalate" | "convert";
+    assignmentId?: string | null;
+  }) {
+    const key = `${action}:${opportunityId}`;
+    setActionBusyKey(key);
+    setNotice(null);
+    try {
+      let endpoint = "";
+      if (action === "route") endpoint = `/api/opportunities/${encodeURIComponent(opportunityId)}/route`;
+      if (action === "accept") endpoint = `/api/assignments/${encodeURIComponent(String(assignmentId || ""))}/accept`;
+      if (action === "escalate") endpoint = `/api/assignments/${encodeURIComponent(String(assignmentId || ""))}/reject`;
+      if (action === "convert") endpoint = `/api/opportunities/${encodeURIComponent(opportunityId)}/convert`;
+      if (!endpoint) throw new Error("Unsupported action");
+
+      const response = await fetch(endpoint, { method: "POST" });
+      const payload = (await response.json().catch(() => ({}))) as { error?: string };
+      if (!response.ok) throw new Error(payload.error || "Action failed");
+
+      const label = action === "route" ? "Opportunity routed" : action === "accept" ? "Assignment accepted" : action === "escalate" ? "Assignment escalated" : "Opportunity converted to job";
+      setNotice(label);
+      await loadOpportunities();
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : "Action failed");
+    } finally {
+      setActionBusyKey(null);
     }
   }
 
@@ -207,6 +259,10 @@ export function OpportunitiesView() {
         </CardBody>
       </Card>
 
+      {notice ? (
+        <div className="rounded-xl border border-semantic-border bg-semantic-surface px-4 py-3 text-sm text-semantic-text">{notice}</div>
+      ) : null}
+
       <Card>
         <CardHeader className="flex flex-row items-center justify-between gap-4">
           <div>
@@ -248,6 +304,7 @@ export function OpportunitiesView() {
                   const sourceLane = getSourceLane(item);
                   const summary = item.distress_context_summary || item.confidence_reasoning || item.description || "Source-backed demand signal.";
                   const sourceBadges = getSourceBadges(item);
+                  const inlineActions = getInlineActions(item);
                   return (
                     <tr key={item.id}>
                       <TD className="border-b border-semantic-border/70 bg-transparent px-0 py-4 first:rounded-none last:rounded-none">
@@ -274,6 +331,9 @@ export function OpportunitiesView() {
                             {formatRelativeTime(item.created_at)}
                             {item.signal_count ? ` · ${item.signal_count} corroborating signals` : ""}
                           </p>
+                          <p className="text-[11px] text-semantic-muted">
+                            Freshness {formatPercent(item.freshness_score)} · Confidence {formatPercent(item.confidence_score)} · Territory {String(item.territory_relevance || "unknown")}
+                          </p>
                         </div>
                       </TD>
                       <TD className="border-b border-semantic-border/70 bg-transparent px-0 py-4 first:rounded-none last:rounded-none">
@@ -290,9 +350,17 @@ export function OpportunitiesView() {
                             Priority {formatPercent(getPriorityScore(item))} · Urgency {formatPercent(item.urgency_score)}
                           </p>
                           <p className="text-xs text-semantic-muted">
-                            {(item.next_recommended_action || "review_signal").replace(/_/g, " ")}
+                            {(item.recommended_next_action || item.next_recommended_action || "review_signal").replace(/_/g, " ")}
                             {item.qualification_reason_code ? ` · ${item.qualification_reason_code.replace(/_/g, " ")}` : ""}
                           </p>
+                          {item.recommended_action_reason ? <p className="text-xs text-semantic-muted">{item.recommended_action_reason}</p> : null}
+                          {item.review_required ? <Badge variant="warning">Review required</Badge> : null}
+                          {item.assignment_status ? (
+                            <p className="text-xs text-semantic-muted">
+                              Assignment {item.assignment_status.replace(/_/g, " ")}
+                              {item.assignment_sla_due_at ? ` · SLA ${formatRelativeTime(item.assignment_sla_due_at)}` : ""}
+                            </p>
+                          ) : null}
                         </div>
                       </TD>
                       <TD className="border-b border-semantic-border/70 bg-transparent px-0 py-4 text-right first:rounded-none last:rounded-none">
@@ -300,6 +368,31 @@ export function OpportunitiesView() {
                           <Link href={action.href} className={buttonStyles({ size: "sm", variant: action.variant })}>
                             {action.label}
                           </Link>
+                          {inlineActions.length > 0 ? (
+                            <div className="flex flex-wrap justify-end gap-2">
+                              {inlineActions.map((inlineAction) => {
+                                const busy = actionBusyKey === `${inlineAction.type}:${item.id}`;
+                                return (
+                                  <Button
+                                    key={`${item.id}-${inlineAction.type}`}
+                                    type="button"
+                                    size="sm"
+                                    variant="ghost"
+                                    disabled={busy || Boolean(actionBusyKey)}
+                                    onClick={() =>
+                                      void runRowAction({
+                                        opportunityId: item.id,
+                                        action: inlineAction.type,
+                                        assignmentId: item.assignment_id
+                                      })
+                                    }
+                                  >
+                                    {busy ? "Working..." : inlineAction.label}
+                                  </Button>
+                                );
+                              })}
+                            </div>
+                          ) : null}
                           <p className="max-w-[12rem] text-right text-xs leading-5 text-semantic-muted">{action.note}</p>
                         </div>
                       </TD>
@@ -401,6 +494,24 @@ function scannerOpportunityHref(item: Opportunity, queue?: "sdr") {
 }
 
 export function getPrimaryAction(item: Opportunity) {
+  if (item.review_required) {
+    return {
+      href: scannerOpportunityHref(item, "sdr"),
+      label: "Review required",
+      variant: "secondary" as const,
+      note: "Opportunity is gated pending verification/review before dispatch or conversion."
+    };
+  }
+
+  if (item.can_convert_to_job) {
+    return {
+      href: `/dashboard/jobs`,
+      label: "Ready to convert",
+      variant: "primary" as const,
+      note: "Dispatch-ready incident. Convert directly to booked job from this queue."
+    };
+  }
+
   if (item.dispatch_ready) {
     return {
       href: `/dashboard/outbound?opportunity=${encodeURIComponent(item.id)}`,
@@ -443,6 +554,15 @@ export function getPrimaryAction(item: Opportunity) {
     variant: "secondary" as const,
     note: "Review the opportunity, confirm fit, and decide whether it belongs in the SDR lane."
   };
+}
+
+export function getInlineActions(item: Opportunity): Array<{ type: "route" | "accept" | "escalate" | "convert"; label: string }> {
+  const actions: Array<{ type: "route" | "accept" | "escalate" | "convert"; label: string }> = [];
+  if (item.can_route_now) actions.push({ type: "route", label: "Route now" });
+  if (item.can_accept_assignment) actions.push({ type: "accept", label: "Accept assignment" });
+  if (item.can_escalate_assignment) actions.push({ type: "escalate", label: "Escalate" });
+  if (item.can_convert_to_job) actions.push({ type: "convert", label: "Convert to job" });
+  return actions;
 }
 
 export function getSourceLane(item: Opportunity): SourceLaneKey {

--- a/src/lib/v2/opportunity-actionability.ts
+++ b/src/lib/v2/opportunity-actionability.ts
@@ -1,0 +1,114 @@
+import { getOpportunityQualificationSnapshot, qualificationAllowsDispatch } from "@/lib/v2/opportunity-qualification";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>;
+  return {};
+}
+
+function asText(value: unknown) {
+  return String(value ?? "").trim();
+}
+
+function toNumber(value: unknown, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function normalizeAssignmentStatus(value: unknown) {
+  const status = asText(value).toLowerCase();
+  if (
+    status === "pending_acceptance" ||
+    status === "accepted" ||
+    status === "escalated" ||
+    status === "complete" ||
+    status === "rejected"
+  ) {
+    return status;
+  }
+  return "";
+}
+
+function isTerminalLifecycle(value: unknown) {
+  const lifecycle = asText(value).toLowerCase();
+  return lifecycle === "booked_job" || lifecycle === "closed_lost";
+}
+
+function hasActiveAssignment(status: string) {
+  return status === "pending_acceptance" || status === "accepted" || status === "escalated";
+}
+
+export type OpportunityActionabilityInput = {
+  lifecycleStatus: unknown;
+  routingStatus: unknown;
+  contactStatus?: unknown;
+  explainability: unknown;
+  assignment?: Record<string, unknown> | null;
+};
+
+export type OpportunityActionability = {
+  recommendedNextAction: string;
+  recommendedActionReason: string | null;
+  recommendedActionSlaMinutes: number | null;
+  freshnessScore: number;
+  confidenceScore: number;
+  territoryRelevance: string | null;
+  reviewRequired: boolean;
+  assignmentId: string | null;
+  assignmentStatus: string | null;
+  assignedTenantId: string | null;
+  assignmentSlaDueAt: string | null;
+  assignmentReason: string | null;
+  canRouteNow: boolean;
+  canAcceptAssignment: boolean;
+  canEscalateAssignment: boolean;
+  canConvertToJob: boolean;
+  dispatchReady: boolean;
+};
+
+export function deriveOpportunityActionability(input: OpportunityActionabilityInput): OpportunityActionability {
+  const explainability = asRecord(input.explainability);
+  const assignment = input.assignment || null;
+  const assignmentStatus = normalizeAssignmentStatus(assignment?.status);
+  const qualification = getOpportunityQualificationSnapshot({
+    explainability,
+    lifecycleStatus: input.lifecycleStatus,
+    contactStatus: input.contactStatus
+  });
+  const dispatchReady = qualificationAllowsDispatch(qualification);
+  const terminal = isTerminalLifecycle(input.lifecycleStatus);
+  const reviewRequired = Boolean(explainability.review_required) || qualification.requiresSdrQualification || qualification.researchOnly;
+  const activeAssignment = hasActiveAssignment(assignmentStatus);
+  const routingStatus = asText(input.routingStatus).toLowerCase();
+  const routeBlockedByStatus = routingStatus === "routed" || routingStatus === "escalated" || routingStatus === "complete";
+
+  const canRouteNow = !terminal && !reviewRequired && !activeAssignment && !routeBlockedByStatus;
+  const canAcceptAssignment = assignmentStatus === "pending_acceptance";
+  const canEscalateAssignment = assignmentStatus === "pending_acceptance" || assignmentStatus === "accepted";
+  const canConvertToJob = !terminal && !reviewRequired && dispatchReady;
+
+  return {
+    recommendedNextAction:
+      asText(explainability.recommended_next_action) ||
+      asText(explainability.next_recommended_action) ||
+      qualification.nextRecommendedAction ||
+      "review_signal",
+    recommendedActionReason: asText(explainability.recommended_action_reason) || null,
+    recommendedActionSlaMinutes: Number.isFinite(Number(explainability.recommended_action_sla_minutes))
+      ? Math.max(0, Math.round(Number(explainability.recommended_action_sla_minutes)))
+      : null,
+    freshnessScore: toNumber(explainability.freshness_score, 0),
+    confidenceScore: toNumber(explainability.confidence_score, 0),
+    territoryRelevance: asText(explainability.territory_relevance) || null,
+    reviewRequired,
+    assignmentId: assignment?.id ? asText(assignment.id) : null,
+    assignmentStatus: assignmentStatus || null,
+    assignedTenantId: assignment?.assigned_tenant_id ? asText(assignment.assigned_tenant_id) : null,
+    assignmentSlaDueAt: assignment?.sla_due_at ? asText(assignment.sla_due_at) : null,
+    assignmentReason: assignment?.assignment_reason ? asText(assignment.assignment_reason) : null,
+    canRouteNow,
+    canAcceptAssignment,
+    canEscalateAssignment,
+    canConvertToJob,
+    dispatchReady
+  };
+}

--- a/src/lib/v2/opportunity-conversion.ts
+++ b/src/lib/v2/opportunity-conversion.ts
@@ -1,0 +1,195 @@
+import { getOpportunityQualificationSnapshot, qualificationAllowsDispatch } from "@/lib/v2/opportunity-qualification";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>;
+  return {};
+}
+
+function asText(value: unknown) {
+  return String(value ?? "").trim();
+}
+
+function toSlaSchedule(slaMinutes: unknown) {
+  const minutes = Number(slaMinutes);
+  if (!Number.isFinite(minutes) || minutes <= 0) return null;
+  return new Date(Date.now() + Math.round(minutes) * 60_000).toISOString();
+}
+
+type SupabaseSingleResult = Promise<{ data: Record<string, unknown> | null; error: { message?: string } | null }>;
+
+type SupabaseChain = {
+  select: (fields: string) => SupabaseChain;
+  eq: (field: string, value: unknown) => SupabaseChain;
+  in: (field: string, values: unknown[]) => SupabaseChain;
+  order: (field: string, options?: { ascending?: boolean }) => SupabaseChain;
+  limit: (count: number) => SupabaseChain;
+  maybeSingle: () => SupabaseSingleResult;
+  single: () => SupabaseSingleResult;
+  insert: (payload: Record<string, unknown>) => SupabaseChain;
+  update: (payload: Record<string, unknown>) => SupabaseChain;
+};
+
+type MinimalSupabase = { from: (table: string) => SupabaseChain };
+
+export type ConvertOpportunityToJobInput = {
+  supabase: MinimalSupabase;
+  tenantId: string;
+  opportunityId: string;
+  actorUserId: string;
+};
+
+export type ConvertOpportunityToJobResult = {
+  created: boolean;
+  opportunityId: string;
+  leadId: string;
+  jobId: string;
+  assignmentUpdated: boolean;
+  warnings: string[];
+};
+
+export async function convertOpportunityToJobV2(input: ConvertOpportunityToJobInput): Promise<ConvertOpportunityToJobResult> {
+  const { supabase, tenantId, opportunityId, actorUserId } = input;
+  const warnings: string[] = [];
+  const nowIso = new Date().toISOString();
+
+  const { data: opportunity, error: opportunityError } = await (supabase
+    .from("v2_opportunities")
+    .select("id,title,service_line,location_text,postal_code,lifecycle_status,contact_status,routing_status,explainability_json")
+    .eq("tenant_id", tenantId)
+    .eq("id", opportunityId)
+    .maybeSingle() as SupabaseSingleResult);
+
+  if (opportunityError || !opportunity?.id) {
+    throw new Error(opportunityError?.message || "Opportunity not found");
+  }
+
+  const explainability = asRecord(opportunity.explainability_json);
+  const qualification = getOpportunityQualificationSnapshot({
+    explainability,
+    lifecycleStatus: opportunity.lifecycle_status,
+    contactStatus: opportunity.contact_status
+  });
+
+  if (Boolean(explainability.review_required) || !qualificationAllowsDispatch(qualification)) {
+    throw new Error("Opportunity requires review/verified contact before conversion");
+  }
+
+  const { data: existingLead } = await (supabase
+    .from("v2_leads")
+    .select("id")
+    .eq("tenant_id", tenantId)
+    .eq("opportunity_id", opportunityId)
+    .maybeSingle() as SupabaseSingleResult);
+
+  let leadId = existingLead?.id ? asText(existingLead.id) : "";
+  let created = false;
+
+  if (!leadId) {
+    const { data: insertedLead, error: leadError } = await (supabase
+      .from("v2_leads")
+      .insert({
+        tenant_id: tenantId,
+        opportunity_id: opportunityId,
+        contact_name: qualification.contactName || asText(explainability.contact_name) || asText(opportunity.title) || "Incident contact",
+        contact_channels_json: {
+          phone: qualification.phone || null,
+          email: qualification.email || null,
+          verification_status: qualification.verificationStatus || "verified",
+          contact_provenance: qualification.qualificationSource || "operator_queue_conversion"
+        },
+        property_address: asText(explainability.address) || asText(opportunity.location_text) || null,
+        city: asText(explainability.city) || null,
+        state: asText(explainability.state) || null,
+        postal_code: asText(opportunity.postal_code) || null,
+        lead_status: "new",
+        owner_user_id: actorUserId,
+        crm_sync_status: "not_synced",
+        do_not_contact: false
+      })
+      .select("id")
+      .single() as SupabaseSingleResult);
+
+    if (leadError || !insertedLead?.id) throw new Error(leadError?.message || "Failed creating v2 lead");
+    leadId = asText(insertedLead.id);
+    created = true;
+  }
+
+  const { data: existingJob } = await (supabase
+    .from("v2_jobs")
+    .select("id")
+    .eq("tenant_id", tenantId)
+    .eq("lead_id", leadId)
+    .maybeSingle() as SupabaseSingleResult);
+
+  let jobId = existingJob?.id ? asText(existingJob.id) : "";
+
+  if (!jobId) {
+    const scheduledAt = toSlaSchedule(explainability.recommended_action_sla_minutes);
+    const { data: insertedJob, error: jobError } = await (supabase
+      .from("v2_jobs")
+      .insert({
+        tenant_id: tenantId,
+        lead_id: leadId,
+        job_type: asText(opportunity.service_line) || "restoration",
+        booked_at: nowIso,
+        scheduled_at: scheduledAt,
+        revenue_amount: 0,
+        status: "booked"
+      })
+      .select("id")
+      .single() as SupabaseSingleResult);
+
+    if (jobError || !insertedJob?.id) throw new Error(jobError?.message || "Failed creating v2 job");
+    jobId = asText(insertedJob.id);
+    created = true;
+  }
+
+  await (supabase
+    .from("v2_opportunities")
+    .update({
+      lifecycle_status: "booked_job",
+      routing_status: "complete",
+      contact_status: "identified",
+      updated_at: nowIso
+    })
+    .eq("tenant_id", tenantId)
+    .eq("id", opportunityId));
+
+  const { data: assignment } = await (supabase
+    .from("v2_assignments")
+    .select("id,status,lead_id")
+    .eq("tenant_id", tenantId)
+    .eq("opportunity_id", opportunityId)
+    .in("status", ["pending_acceptance", "accepted", "escalated"])
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle() as SupabaseSingleResult);
+
+  let assignmentUpdated = false;
+  if (assignment?.id) {
+    const assignmentUpdate = (await (supabase
+      .from("v2_assignments")
+      .update({
+        status: "complete",
+        completed_at: nowIso,
+        lead_id: assignment.lead_id || leadId
+      })
+      .eq("id", asText(assignment.id)))) as unknown as { error?: { message?: string } | null };
+    const updateAssignmentError = assignmentUpdate.error || null;
+
+    if (!updateAssignmentError) {
+      assignmentUpdated = true;
+    } else {
+      warnings.push(`assignment_update_failed:${updateAssignmentError.message || "unknown"}`);
+    }
+  }
+
+  return {
+    created,
+    opportunityId,
+    leadId,
+    jobId,
+    assignmentUpdated,
+    warnings
+  };
+}

--- a/tests/opportunities-view-behavior.spec.ts
+++ b/tests/opportunities-view-behavior.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { getPrimaryAction, getSourceLane, type Opportunity } from "../src/components/dashboard/opportunities-view";
+import { getInlineActions, getPrimaryAction, getSourceLane, type Opportunity } from "../src/components/dashboard/opportunities-view";
 
 function makeOpportunity(overrides: Partial<Opportunity> = {}): Opportunity {
   return {
@@ -145,6 +145,58 @@ test("mold_biohazard opportunities remain SDR-gated until verified contact is di
     expect.objectContaining({
       href: "/dashboard/outbound?opportunity=opp-biohazard-qualified",
       label: "Launch buyer flow"
+    })
+  );
+});
+
+test("review-required opportunities stay routed to review lane", () => {
+  const item = makeOpportunity({
+    id: "opp-review",
+    review_required: true,
+    can_route_now: false,
+    can_convert_to_job: false
+  });
+
+  expect(getPrimaryAction(item)).toEqual(
+    expect.objectContaining({
+      href: "/dashboard/scanner?queue=sdr&opportunity=opp-review",
+      label: "Review required"
+    })
+  );
+});
+
+test("inline actions expose routing and assignment controls when available", () => {
+  const item = makeOpportunity({
+    id: "opp-actions",
+    can_route_now: true,
+    can_accept_assignment: true,
+    can_escalate_assignment: true,
+    can_convert_to_job: false
+  });
+
+  expect(getInlineActions(item)).toEqual([
+    { type: "route", label: "Route now" },
+    { type: "accept", label: "Accept assignment" },
+    { type: "escalate", label: "Escalate" }
+  ]);
+});
+
+test("inline actions include convert-to-job when dispatch-ready", () => {
+  const item = makeOpportunity({
+    id: "opp-convert",
+    can_convert_to_job: true,
+    dispatch_ready: true,
+    qualification_status: "qualified_contactable",
+    verification_status: "verified",
+    research_only: false,
+    requires_sdr_qualification: false
+  });
+
+  expect(getInlineActions(item)).toContainEqual({ type: "convert", label: "Convert to job" });
+  expect(getPrimaryAction(item)).toEqual(
+    expect.objectContaining({
+      href: "/dashboard/jobs",
+      label: "Ready to convert"
     })
   );
 });

--- a/tests/v2-opportunity-actionability.spec.ts
+++ b/tests/v2-opportunity-actionability.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+import { deriveOpportunityActionability } from "../src/lib/v2/opportunity-actionability";
+
+test("actionability exposes route-ready controls for non-gated incident opportunities", () => {
+  const actionability = deriveOpportunityActionability({
+    lifecycleStatus: "new",
+    routingStatus: "pending",
+    contactStatus: "identified",
+    explainability: {
+      qualification_status: "qualified_contactable",
+      verification_status: "verified",
+      phone: "+17165551212",
+      confidence_score: 84,
+      freshness_score: 90,
+      recommended_next_action: "dispatch_now",
+      territory_relevance: "high",
+      review_required: false
+    },
+    assignment: null
+  });
+
+  expect(actionability.canRouteNow).toBeTruthy();
+  expect(actionability.canConvertToJob).toBeTruthy();
+  expect(actionability.reviewRequired).toBeFalsy();
+});
+
+test("review-required opportunities are gated from route and convert actions", () => {
+  const actionability = deriveOpportunityActionability({
+    lifecycleStatus: "new",
+    routingStatus: "pending",
+    contactStatus: "unknown",
+    explainability: {
+      qualification_status: "queued_for_sdr",
+      review_required: true,
+      recommended_next_action: "verify_location_then_route"
+    },
+    assignment: null
+  });
+
+  expect(actionability.reviewRequired).toBeTruthy();
+  expect(actionability.canRouteNow).toBeFalsy();
+  expect(actionability.canConvertToJob).toBeFalsy();
+});
+
+test("assignment controls map to pending assignment lifecycle", () => {
+  const actionability = deriveOpportunityActionability({
+    lifecycleStatus: "assigned",
+    routingStatus: "routed",
+    contactStatus: "identified",
+    explainability: {
+      qualification_status: "qualified_contactable",
+      verification_status: "verified",
+      phone: "+17165551212",
+      review_required: false
+    },
+    assignment: {
+      id: "assignment-1",
+      status: "pending_acceptance",
+      assigned_tenant_id: "tenant-1",
+      sla_due_at: "2026-04-07T12:00:00.000Z",
+      assignment_reason: "territory_match"
+    }
+  });
+
+  expect(actionability.assignmentId).toBe("assignment-1");
+  expect(actionability.canAcceptAssignment).toBeTruthy();
+  expect(actionability.canEscalateAssignment).toBeTruthy();
+  expect(actionability.canRouteNow).toBeFalsy();
+});
+
+test("actionability preserves qualification-derived next action when incident override is absent", () => {
+  const actionability = deriveOpportunityActionability({
+    lifecycleStatus: "new",
+    routingStatus: "pending",
+    contactStatus: "unknown",
+    explainability: {
+      qualification_status: "queued_for_sdr"
+    },
+    assignment: null
+  });
+
+  expect(actionability.recommendedNextAction).toBe("await_sdr_review");
+  expect(actionability.reviewRequired).toBeTruthy();
+});

--- a/tests/v2-opportunity-conversion.spec.ts
+++ b/tests/v2-opportunity-conversion.spec.ts
@@ -1,0 +1,228 @@
+import { expect, test } from "@playwright/test";
+import { convertOpportunityToJobV2 } from "../src/lib/v2/opportunity-conversion";
+
+function createSupabaseMock() {
+  const tables = {
+    opportunities: [
+      {
+        id: "opp-1",
+        tenant_id: "tenant-1",
+        title: "Water emergency",
+        service_line: "restoration",
+        location_text: "Buffalo, NY 14201",
+        postal_code: "14201",
+        lifecycle_status: "assigned",
+        contact_status: "identified",
+        routing_status: "routed",
+        explainability_json: {
+          qualification_status: "qualified_contactable",
+          verification_status: "verified",
+          phone: "+17165550000",
+          review_required: false,
+          recommended_action_sla_minutes: 30
+        }
+      }
+    ] as Array<Record<string, unknown>>,
+    leads: [] as Array<Record<string, unknown>>,
+    jobs: [] as Array<Record<string, unknown>>,
+    assignments: [
+      {
+        id: "assignment-1",
+        tenant_id: "tenant-1",
+        opportunity_id: "opp-1",
+        status: "pending_acceptance",
+        lead_id: null,
+        created_at: "2026-04-06T10:00:00.000Z"
+      }
+    ] as Array<Record<string, unknown>>
+  };
+
+  const supabase = {
+    from(table: string) {
+      if (table === "v2_opportunities") {
+        return {
+          select: () => {
+            const state = { tenantId: "", opportunityId: "" };
+            const builder = {
+              eq: (field: string, value: unknown) => {
+                if (field === "tenant_id") state.tenantId = String(value || "");
+                if (field === "id") state.opportunityId = String(value || "");
+                return builder;
+              },
+              maybeSingle: async () => ({
+                data:
+                  tables.opportunities.find(
+                    (row) => String(row.tenant_id) === state.tenantId && String(row.id) === state.opportunityId
+                  ) || null,
+                error: null
+              })
+            };
+            return builder;
+          },
+          update: (patch: Record<string, unknown>) => ({
+            eq: (_field1: string, tenantId: unknown) => ({
+              eq: async (_field2: string, opportunityId: unknown) => {
+                const index = tables.opportunities.findIndex(
+                  (row) => String(row.tenant_id) === String(tenantId) && String(row.id) === String(opportunityId)
+                );
+                if (index >= 0) tables.opportunities[index] = { ...tables.opportunities[index], ...patch };
+                return { data: null, error: null };
+              }
+            })
+          })
+        };
+      }
+
+      if (table === "v2_leads") {
+        return {
+          select: () => {
+            const state = { tenantId: "", opportunityId: "" };
+            const builder = {
+              eq: (field: string, value: unknown) => {
+                if (field === "tenant_id") state.tenantId = String(value || "");
+                if (field === "opportunity_id") state.opportunityId = String(value || "");
+                return builder;
+              },
+              maybeSingle: async () => ({
+                data:
+                  tables.leads.find(
+                    (row) => String(row.tenant_id) === state.tenantId && String(row.opportunity_id) === state.opportunityId
+                  ) || null,
+                error: null
+              })
+            };
+            return builder;
+          },
+          insert: (payload: Record<string, unknown>) => ({
+            select: () => ({
+              single: async () => {
+                const row = { id: `lead-${tables.leads.length + 1}`, ...payload };
+                tables.leads.push(row);
+                return { data: row, error: null };
+              }
+            })
+          })
+        };
+      }
+
+      if (table === "v2_jobs") {
+        return {
+          select: () => ({
+            eq: (_field1: string, tenantId: unknown) => ({
+              eq: (_field2: string, leadId: unknown) => ({
+                maybeSingle: async () => ({
+                  data:
+                    tables.jobs.find(
+                      (row) => String(row.tenant_id) === String(tenantId) && String(row.lead_id) === String(leadId)
+                    ) || null,
+                  error: null
+                })
+              })
+            })
+          }),
+          insert: (payload: Record<string, unknown>) => ({
+            select: () => ({
+              single: async () => {
+                const row = { id: `job-${tables.jobs.length + 1}`, ...payload };
+                tables.jobs.push(row);
+                return { data: row, error: null };
+              }
+            })
+          })
+        };
+      }
+
+      if (table === "v2_assignments") {
+        return {
+          select: () => ({
+            eq: (_field1: string, tenantId: unknown) => ({
+              eq: (_field2: string, opportunityId: unknown) => ({
+                in: () => ({
+                  order: () => ({
+                    limit: () => ({
+                      maybeSingle: async () => ({
+                        data:
+                          tables.assignments.find(
+                            (row) => String(row.tenant_id) === String(tenantId) && String(row.opportunity_id) === String(opportunityId)
+                          ) || null,
+                        error: null
+                      })
+                    })
+                  })
+                })
+              })
+            })
+          }),
+          update: (patch: Record<string, unknown>) => ({
+            eq: async (_field: string, assignmentId: unknown) => {
+              const index = tables.assignments.findIndex((row) => String(row.id) === String(assignmentId));
+              if (index >= 0) tables.assignments[index] = { ...tables.assignments[index], ...patch };
+              return { data: null, error: null };
+            }
+          })
+        };
+      }
+
+      throw new Error(`Unhandled table ${table}`);
+    }
+  };
+
+  return { supabase: supabase as never, tables };
+}
+
+test("convert opportunity to job creates lead + job and closes assignment", async () => {
+  const { supabase, tables } = createSupabaseMock();
+
+  const result = await convertOpportunityToJobV2({
+    supabase,
+    tenantId: "tenant-1",
+    opportunityId: "opp-1",
+    actorUserId: "user-1"
+  });
+
+  expect(result.created).toBeTruthy();
+  expect(result.leadId).toBe("lead-1");
+  expect(result.jobId).toBe("job-1");
+  expect(result.assignmentUpdated).toBeTruthy();
+  expect(String(tables.opportunities[0]?.lifecycle_status)).toBe("booked_job");
+  expect(String(tables.assignments[0]?.status)).toBe("complete");
+});
+
+test("convert opportunity to job is idempotent when lead/job already exist", async () => {
+  const { supabase, tables } = createSupabaseMock();
+  tables.leads.push({ id: "lead-existing", tenant_id: "tenant-1", opportunity_id: "opp-1" });
+  tables.jobs.push({ id: "job-existing", tenant_id: "tenant-1", lead_id: "lead-existing", status: "booked" });
+
+  const result = await convertOpportunityToJobV2({
+    supabase,
+    tenantId: "tenant-1",
+    opportunityId: "opp-1",
+    actorUserId: "user-1"
+  });
+
+  expect(result.created).toBeFalsy();
+  expect(result.leadId).toBe("lead-existing");
+  expect(result.jobId).toBe("job-existing");
+  expect(tables.leads).toHaveLength(1);
+  expect(tables.jobs).toHaveLength(1);
+});
+
+test("convert opportunity to job blocks review-required opportunities", async () => {
+  const { supabase, tables } = createSupabaseMock();
+  tables.opportunities[0] = {
+    ...tables.opportunities[0],
+    explainability_json: {
+      qualification_status: "queued_for_sdr",
+      review_required: true
+    }
+  };
+
+  await expect(
+    convertOpportunityToJobV2({
+      supabase,
+      tenantId: "tenant-1",
+      opportunityId: "opp-1",
+      actorUserId: "user-1"
+    })
+  ).rejects.toThrow(/requires review/i);
+});


### PR DESCRIPTION
## What changed
- Extended v2 opportunities API output with additive incident actionability fields: recommended action details, freshness/confidence context, territory relevance, review gating, and latest assignment metadata.
- Added computed queue action booleans (`can_route_now`, `can_accept_assignment`, `can_escalate_assignment`, `can_convert_to_job`) while preserving existing response shape.
- Added new v2 endpoint `POST /api/opportunities/[id]/convert` for idempotent opportunity-to-job conversion (create/ensure v2 lead + v2 job, complete active assignment, mark opportunity booked).
- Upgraded opportunities queue UI with narrow operator controls (Route now, Accept assignment, Escalate, Convert to job) plus clear review-required gating and actionability context.
- Added targeted regression tests for queue actionability, review/approval gating, assignment controls, convert-to-job happy/idempotent/guard paths, and explainability fallback behavior.
- Added PR #42 prep artifact selecting permits as the next source family and outlining branch/test setup without implementation.

## Why this matters to lead quality / job conversion
- Operators can now move incident opportunities from signal to assignment/job with fewer clicks and clearer trust signals.
- Review-required records are explicitly gated, reducing risky outreach/dispatch on weak signals.
- Conversion path is idempotent and ties back to v2 lead/job records for cleaner downstream job tracking.

## Exact risk areas reviewed
- Accidental breakage of existing opportunities API consumers (kept additive fields only).
- Incorrect route/accept/escalate/convert visibility in queue.
- Non-idempotent conversion creating duplicate v2 leads/jobs.
- Review-required opportunities bypassing qualification safeguards.
- Assignment completion consistency during conversion.

## Tests run
- npm run typecheck
- npm test -- tests/opportunities-view-behavior.spec.ts tests/v2-opportunity-actionability.spec.ts tests/v2-opportunity-conversion.spec.ts
- npm test -- tests/v2-scoring.spec.ts tests/v2-multi-signal-scoring.spec.ts tests/v2-territory-routing.spec.ts tests/v2-firecrawl-incident-operator-flow.spec.ts tests/opportunities-view-behavior.spec.ts tests/v2-opportunity-actionability.spec.ts tests/v2-opportunity-conversion.spec.ts
- npm run build

## Next slice
PR #42: permits source family activation (implementation starts only after PR #41 review stability). Prep doc committed in this PR.